### PR TITLE
ストリークリセット機能を修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :store_devise_errors_as_flash, if: :devise_controller?
+  before_action :check_streak, if: :user_signed_in?
 
   protected
 
@@ -17,5 +18,9 @@ class ApplicationController < ActionController::Base
     return unless resource&.errors&.any?
 
     flash.now[:alert] = "入力内容に不備がある"
+  end
+
+  def check_streak
+    current_user.reset_streak_if_needed!
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,4 +22,22 @@ class User < ApplicationRecord
       update!(streak: 1)
     end
   end
+
+  def reset_streak_if_needed!
+    yesterday = Time.zone.yesterday
+    today = Time.zone.today
+
+    if records.where(created_at: yesterday.all_day).exists?
+      # 昨日 Record がある → streak 継続の可能性、何もしない
+      return
+    end
+
+    if records.where(created_at: today.all_day).exists?
+      # 今日 Record がある → streak は途切れて今日から 1
+      update!(streak: 1)
+    else
+      # 今日 Record がない → streak は 0 にリセット
+      update!(streak: 0)
+    end
+  end
 end


### PR DESCRIPTION
## 修正内容
ログイン時に streak を補正する処理を修正しました。

- 修正前: `reset_streak_if_needed!` は「昨日 Record がない場合は無条件で streak = 0」としていたため、今日の Record があってもリセットされてしまう問題がありました。
- 修正後: 
  - 昨日 Recordがある場合、かつ、今日 Record がない場合 → 何もしない
  - 昨日 Recordがない場合、かつ、今日 Record がある場合 → streak = 1
  - 昨日 Recordがない場合、かつ、今日 Record がない場合 → streak = 0

## 動作確認手順

1. 今日の Record を削除する:
user.records.where(created_at: Time.zone.today.all_day).destroy_all

2. ログイン時に streak リセットを呼ぶ:
user.reset_streak_if_needed!


3. streak の確認:
- 昨日 Recordがある場合、かつ、今日 Record がない場合 → 何もしない
- 昨日 Recordがない場合、かつ、今日 Record がある場合 → streak = 1
- 昨日 Recordがない場合、かつ、今日 Record がない場合 → streak = 0

この修正により、今日の投稿があるのに streak がリセットされる問題が解消され、既存の streak ロジックとの整合性も保たれている。
