### PR TITLE
エラー修正: remove javascript link_tree to resolve Sprockets::DoubleLinkError

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
-//= link_tree ../../javascript .js
-//= link_tree ../../../vendor/javascript .js
 //= link_tree ../builds
+//= link_tree ../../../vendor/javascript .js


### PR DESCRIPTION
## 概要

Sprockets::DoubleLinkError の解消対応。

jsbundling(esbuild)導入後も
app/assets/config/manifest.js に
`link_tree ../../javascript .js` が残っていたため、
application.js が二重リンクされていました。

## 対応内容

- manifest.js から `link_tree ../../javascript .js` を削除
- builds ディレクトリのみをリンクする構成に修正

## 期待効果

- application.js の重複リンク解消
- Renderでのassets:precompileエラー解消
