### PR TITLE
UUID public_id をrecords に追加

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -4,4 +4,7 @@ class Record < ApplicationRecord
 
   validates :activity_id, presence: true
 
+  def to_param
+    public_id
+  end
 end

--- a/db/migrate/20260217063738_enable_pgcrypto.rb
+++ b/db/migrate/20260217063738_enable_pgcrypto.rb
@@ -1,0 +1,5 @@
+class EnablePgcrypto < ActiveRecord::Migration[7.1]
+  def change
+    enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
+  end
+end

--- a/db/migrate/20260217063937_add_public_id_to_record.rb
+++ b/db/migrate/20260217063937_add_public_id_to_record.rb
@@ -1,0 +1,7 @@
+class AddPublicIdToRecord < ActiveRecord::Migration[7.1]
+  def change
+    add_column :records, :public_id, :uuid, default: "gen_random_uuid()",null: false
+    add_index  :records, :public_id, unique: true
+    #Ex:- add_index("admin_users", "username")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_01_09_142408) do
+ActiveRecord::Schema[7.1].define(version: 2026_02_17_063937) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "activities", force: :cascade do |t|
@@ -27,7 +28,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_09_142408) do
     t.text "memo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "public_id", default: -> { "gen_random_uuid()" }, null: false
     t.index ["activity_id"], name: "index_records_on_activity_id"
+    t.index ["public_id"], name: "index_records_on_public_id", unique: true
     t.index ["user_id"], name: "index_records_on_user_id"
   end
 


### PR DESCRIPTION
## 概要

外部公開を想定し、recordsテーブルにpublic_id(UUID)を追加しました。

## 目的

- 連番IDの外部露出を避けるため
- 推測耐性を高める設計とするため

## 変更内容

- pgcrypto拡張を有効化
- recordsにpublic_id(UUID)を追加
  - default: gen_random_uuid()
  - null: false
  - unique index付与

## 備考

内部の主キー(id)はそのまま維持。
外部公開用の識別子としてpublic_idを利用予定。