### PR TITLE
今日の記録画面にAPIロジックを追加

### DIFF
--- a/app/controllers/api/dashboard_controller.rb
+++ b/app/controllers/api/dashboard_controller.rb
@@ -1,0 +1,68 @@
+class Api::DashboardController < ApplicationController
+  before_action :authenticate_user!
+
+  def today
+    now = Time.current
+    start_at = now.beginning_of_day
+    end_at   = now.end_of_day
+
+    logs = current_user.records
+                       .includes(:activity)
+                       .where(logged_at: start_at..end_at)
+                       .order(:logged_at)
+
+    render json: {
+      logs: build_logs_json(logs),
+      summary_per_category: summarize_per_activity(logs, now),
+      current_log: logs.last ? build_record_json(logs.last) : nil,
+      now: now.iso8601
+    }
+  end
+
+  private
+
+  def build_logs_json(logs)
+    logs.map { |r| build_record_json(r) }
+  end
+
+  def build_record_json(record)
+    {
+      id: record.public_id,
+      activity: {
+        id: record.activity.public_id,
+        name: record.activity.name
+      },
+      logged_at: record.logged_at.in_time_zone("Tokyo").iso8601,
+      memo: record.memo
+    }
+  end
+
+  def summarize_per_activity(logs, now)
+    return [] if logs.empty?
+
+    sums = Hash.new { |h, k| h[k] = { total_minutes: 0, count: 0, activity_name: nil } }
+
+    logs.each_with_index do |log, i|
+      next_time = logs[i + 1]&.logged_at || now
+
+      diff_minutes = ((next_time - log.logged_at) / 60).floor
+      diff_minutes = 0 if diff_minutes.negative?
+      diff_minutes = [diff_minutes, 360].min
+
+      key = log.activity.public_id
+
+      sums[key][:total_minutes] += diff_minutes
+      sums[key][:count] += 1
+      sums[key][:activity_name] ||= log.activity.name
+    end
+
+    sums.map do |activity_id, v|
+      {
+        activity_id: activity_id,
+        activity_name: v[:activity_name],
+        total_minutes: v[:total_minutes],
+        count: v[:count]
+      }
+    end.sort_by { |h| -h[:total_minutes] }
+  end
+end

--- a/app/controllers/study_records_controller.rb
+++ b/app/controllers/study_records_controller.rb
@@ -7,6 +7,7 @@ class StudyRecordsController < ApplicationController
 
   def create
     @record = current_user.records.new(record_params)
+    @record.logged_at ||= Time.current
 
     if @record.save
       redirect_to learning_path, notice: "記録しました"

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -3,8 +3,15 @@ class Record < ApplicationRecord
   belongs_to :activity
 
   validates :activity_id, presence: true
+  before_create :set_logged_at
 
   def to_param
     public_id
+  end
+
+  private
+
+  def set_logged_at
+    selef.logged_at ||= Time.current
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,4 +20,8 @@ Rails.application.routes.draw do
 
   get 'analytics_path', to: 'records#analytics', as: 'analytics_records'
   resources :records
+
+  namespace :api do
+    get "dashboard/today", to: "dashboard#today"
+  end
 end

--- a/db/migrate/20260217105118_add_public_id_to_activity.rb
+++ b/db/migrate/20260217105118_add_public_id_to_activity.rb
@@ -1,0 +1,6 @@
+class AddPublicIdToActivity < ActiveRecord::Migration[7.1]
+  def change
+    add_column :activities, :public_id, :uuid, default: "gen_random_uuid()", null: false
+    add_index  :activities, :public_id, unique: true
+  end
+end

--- a/db/migrate/20260217110914_add_logged_at_to_record.rb
+++ b/db/migrate/20260217110914_add_logged_at_to_record.rb
@@ -1,0 +1,5 @@
+class AddLoggedAtToRecord < ActiveRecord::Migration[7.1]
+  def change
+    add_column :records, :logged_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_02_17_063937) do
+ActiveRecord::Schema[7.1].define(version: 2026_02_17_110914) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -20,6 +20,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_17_063937) do
     t.string "icon"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "public_id", default: -> { "gen_random_uuid()" }, null: false
+    t.index ["public_id"], name: "index_activities_on_public_id", unique: true
   end
 
   create_table "records", force: :cascade do |t|
@@ -29,6 +31,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_17_063937) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "public_id", default: -> { "gen_random_uuid()" }, null: false
+    t.datetime "logged_at"
     t.index ["activity_id"], name: "index_records_on_activity_id"
     t.index ["public_id"], name: "index_records_on_public_id", unique: true
     t.index ["user_id"], name: "index_records_on_user_id"


### PR DESCRIPTION
## 概要
ダッシュボード用に、今日のログとカテゴリ別サマリを返すJSON APIを追加しました。

## 変更内容
- recordsに logged_at を追加
- GET /api/dashboard/today を追加
  - logs（今日のログ一覧）
  - summary_per_category（6時間上限ルールで集計）
  - current_log（最新ログ）
  - now（クライアント計算用）

## 動作確認
- /api/dashboard/today でJSONが返る
- 今日ログ0件でも logs: [] で返る