### PR TITLE
現在の行動と推定経過時間を表示するCurrentStatusを実装

### DIFF
--- a/app/javascript/react/dashboard/DashboardApp.jsx
+++ b/app/javascript/react/dashboard/DashboardApp.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { fetchToday, fetchActivities, postLog } from "./api";
 import LogForm from "./components/LogForm";
 import TodayHistory from "./components/TodayHistory";
+import CurrentStatus from "./components/CurrentStatus"; 
 
 export default function DashboardApp() {
   const [dashboard, setDashboard] = useState(null);
@@ -42,15 +43,15 @@ export default function DashboardApp() {
 
   return (
     <div style={{ display: "flex", gap: 24, alignItems: "flex-start", padding: 24 }}>
-      <div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
         {error && <div className="alert alert-danger">{error}</div>}
         <LogForm
           activities={activities}
           onSubmit={handleSubmit}
           isSubmitting={isSubmitting}
         />
+        <CurrentStatus dashboard={dashboard} activities={activities} />
       </div>
-
       <TodayHistory logs={logs} activities={activities} />
     </div>
   );

--- a/app/javascript/react/dashboard/components/CurrentStatus.jsx
+++ b/app/javascript/react/dashboard/components/CurrentStatus.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+export default function CurrentStatus({ dashboard, activities }) {
+    const currentLog = dashboard?.current_log ?? null;
+
+    console.log("CurrentStatus", { currentLog, activities });
+
+
+    const now = dashboard?.now ? new Date(dashboard.now) : new Date();
+
+    // 現在の行動名
+    const activity = activities.find((a) => a.id === currentLog?.activity?.id);
+    const activityName = activity ? `${activity.icon} ${activity.name}` : "未選択";
+
+    // 推定経過時間（分）、最大360分
+    const elapsedMinutes = currentLog
+    ? Math.min(
+        Math.floor((now - new Date(currentLog.logged_at)) /1000 /60),
+        360
+    )
+    : 0;
+
+    return (
+        <div style={{
+            width: 320,
+            background: "#ffffff",
+            borderRadius: 16,
+            border: "1px solid #e5e7eb",
+            padding: "20px",
+            bosShadow: "0 4px 24px rgba(0, 0, 0, 0.08)",
+        }}>
+          <p style={{
+            color: "#9ca3af",
+            fontSize: 10,
+            letterSpacing: "0.5em",
+            textTransform: "uppercase",
+            margin: "0 0 12px",
+          }}>TODAY'S ESTIMATE</p>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <div style={{ display: "flex", aliginItems: "center", gap: 8}}>
+                <span style={{ color: "#6b7280", fontSize: 13 }}>現在</span>
+                <span style={{ fontSize: 14, fontWeight: 700, color: "#111827" }}>
+                    {activityName}中
+                </span>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <span style={{ color: "#6b7280", fontSize: 13 }}>推定経過時間</span>
+                <span style={{ fontSize: 14, fontWeight: 700, color: "#7c3aed" }}>
+                    {elapsedMinutes}分
+                </span>
+            </div>
+          </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## 概要
「今日の推定時間」ブロックを新規コンポーネントとして実装しました。
現在取り組んでいる行動と、最後のログからの推定経過時間を表示します。

## 変更内容

### 新規ファイル
- `app/javascript/react/dashboard/components/CurrentStatus.jsx`
  - 最新ログのカテゴリ名を「現在：◯◯中」として表示
  - `now - current_log.logged_at` を分に変換して表示（最大360分）
  - ログがない場合は「未選択」「0分」を表示

### 変更ファイル
- `app/javascript/react/dashboard/DashboardApp.jsx`
  - `CurrentStatus` を import して左下に配置
  - レイアウトを左列（フォーム＋CurrentStatus）・右列（履歴）の2カラムに変更

## 動作確認
- [x] ログがあるとき「現在：◯◯中」「推定経過時間：◯分」が表示される
- [x] ログがないとき「現在：未選択中」「推定経過時間：0分」が表示される
- [x] 経過時間が360分を超えても360分で止まる