### PR TITLE
カテゴリ別サマリーと円グラフを表示するSummaryStatusを実装

### DIFF
--- a/app/javascript/react/dashboard/DashboardApp.jsx
+++ b/app/javascript/react/dashboard/DashboardApp.jsx
@@ -3,6 +3,7 @@ import { fetchToday, fetchActivities, postLog } from "./api";
 import LogForm from "./components/LogForm";
 import TodayHistory from "./components/TodayHistory";
 import CurrentStatus from "./components/CurrentStatus"; 
+import SummaryStatus from "./components/SummaryStatus";
 
 export default function DashboardApp() {
   const [dashboard, setDashboard] = useState(null);
@@ -52,6 +53,7 @@ export default function DashboardApp() {
         />
         <CurrentStatus dashboard={dashboard} activities={activities} />
       </div>
+      <SummaryStatus dashboard={dashboard} />
       <TodayHistory logs={logs} activities={activities} />
     </div>
   );

--- a/app/javascript/react/dashboard/components/SummaryStatus.jsx
+++ b/app/javascript/react/dashboard/components/SummaryStatus.jsx
@@ -1,0 +1,85 @@
+import React from "react";
+import DonutChart from "./charts/DonutChart";
+
+const COLORS = ["#a855f7", "#3b82f6", "#10b981", "#f59e0b", "#ef4444"];
+
+const MESSAGES = [
+  "ナイスペース！",
+  "いい調子だよ！",
+  "継続は力なり！",
+  "今日もお疲れ様！",
+];
+
+function getMessage(logs) {
+  if (!logs || logs.length === 0) return "さあ、はじめよう！";
+  if (logs.length >= 5) return "すごいペース！";
+  return MESSAGES[logs.length % MESSAGES.length];
+}
+
+export default function SummaryStatus({ dashboard }) {
+  const summary = dashboard?.summary_per_category ?? [];
+  const logs = dashboard?.logs ?? [];
+
+  return (
+    <div style={{
+      width: 320,
+      background: "#ffffff",
+      borderRadius: 16,
+      border: "1px solid #e5e7eb",
+      padding: "20px",
+      boxShadow: "0 4px 24px rgba(0,0,0,0.08)",
+    }}>
+      <p style={{
+        color: "#9ca3af",
+        fontSize: 10,
+        letterSpacing: "0.15em",
+        textTransform: "uppercase",
+        margin: "0 0 12px",
+      }}>TODAY'S SUMMARY</p>
+
+      {summary.length === 0 ? (
+        <p style={{ color: "#9ca3af", fontSize: 13 }}>まだ記録がありません</p>
+      ) : (
+        <>
+          {/* カテゴリ別時間・回数 */}
+          <ul style={{ listStyle: "none", padding: 0, margin: "0 0 16px", display: "flex", flexDirection: "column", gap: 6 }}>
+            {summary.map((s, i) => {
+              const hours = Math.floor(s.total_minutes / 60);
+              const minutes = s.total_minutes % 60;
+              const timeStr = hours > 0 ? `${hours}時間${minutes}分` : `${minutes}分`;
+              return (
+                <li key={s.activity_id} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", fontSize: 13 }}>
+                  <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <span style={{ width: 10, height: 10, borderRadius: "50%", background: COLORS[i % COLORS.length], display: "inline-block" }} />
+                    <span style={{ color: "#374151" }}>{s.activity_name}</span>
+                  </span>
+                  <span style={{ color: "#6b7280" }}>{timeStr}（{s.count}回）</span>
+                </li>
+              );
+            })}
+          </ul>
+
+          {/* 円グラフ */}
+          <div style={{ display: "flex", justifyContent: "center", marginBottom: 16 }}>
+            <DonutChart
+              labels={summary.map((s) => s.activity_name)}
+              values={summary.map((s) => s.total_minutes)}
+              colors={summary.map((_, i) => COLORS[i % COLORS.length])}
+            />
+          </div>
+
+          {/* コメント */}
+          <p style={{
+            textAlign: "center",
+            fontSize: 13,
+            color: "#7c3aed",
+            fontWeight: 600,
+            margin: 0,
+          }}>
+            🐹「{getMessage(logs)}」
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/javascript/react/dashboard/components/charts/DonutChart.jsx
+++ b/app/javascript/react/dashboard/components/charts/DonutChart.jsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useRef } from "react";
+
+export default function DonutChart({ labels, values, colors, size = 160 }) {
+  const canvasRef = useRef(null);
+  const chartRef = useRef(null);
+
+  useEffect(() => {
+    if (!canvasRef.current || values.length === 0) return;
+
+    if (chartRef.current) chartRef.current.destroy();
+
+    const ctx = canvasRef.current.getContext("2d");
+    chartRef.current = new window.Chart(ctx, {
+      type: "doughnut",
+      data: {
+        labels,
+        datasets: [{
+          data: values,
+          backgroundColor: colors,
+          borderWidth: 2,
+          borderColor: "#ffffff",
+        }],
+      },
+      options: {
+        responsive: false,
+        plugins: {
+          legend: { display: false },
+        },
+      },
+    });
+
+    return () => {
+      if (chartRef.current) chartRef.current.destroy();
+    };
+  }, [labels, values, colors]);
+
+  return <canvas ref={canvasRef} width={size} height={size} />;
+}


### PR DESCRIPTION
## 概要
「現在の状態」ブロックを新規コンポーネントとして実装しました。
今日のカテゴリ別時間・回数・円グラフ・ハムスターのコメントを表示します。

## 変更内容

### 新規ファイル
- `app/javascript/react/dashboard/components/SummaryStatus.jsx`
  - `summary_per_category` からカテゴリ別時間・回数を表示
  - ハムスターのコメントをログ数に応じて表示
  - ログがない場合「まだ記録がありません」を表示

- `app/javascript/react/dashboard/components/charts/DonutChart.jsx`
  - Chart.jsを使った円グラフコンポーネント
  - `labels`・`values`・`colors` を props で受け取る設計
  - 週次記録など他のページでも再利用可能

### 変更ファイル
- `app/javascript/react/dashboard/DashboardApp.jsx`
  - `SummaryStatus` を import して右上に配置

## 設計メモ
円グラフは `DonutChart.jsx` として独立させ、データの加工は各コンポーネントが担当する設計にしました。週次記録ページでも同じ `DonutChart` を再利用できます。

## 動作確認
- [x] ログが複数あるとき「カテゴリ別時間＋回数」が表示される
- [x] 円グラフでカテゴリ別割合が見える
- [x] ログがない場合「まだ記録がありません」が表示される
- [x] ハムスターのコメントが表示される