### PR TITLE
記録後のstate直接更新とDonutChart二重描画の修正

### DIFF
--- a/app/controllers/api/dashboard_logs_controller.rb
+++ b/app/controllers/api/dashboard_logs_controller.rb
@@ -3,25 +3,22 @@ class Api::DashboardLogsController < ApplicationController
 
   def create
     activity = Activity.find_by!(public_id: params[:activity_id])
-
     record = current_user.records.new(
       activity:  activity,
       memo:      params[:memo],
       logged_at: Time.zone.now
     )
-
     if record.save
+      now = Time.current
+      logs = current_user.records
+                         .includes(:activity)
+                         .where(logged_at: now.beginning_of_day..now.end_of_day)
+                         .order(:logged_at)
       render json: {
         ok: true,
-        record: {
-          id: record.public_id,
-          activity: {
-            id: activity.public_id,
-            name: activity.name
-          },
-          logged_at: record.logged_at.in_time_zone("Tokyo").iso8601,
-          memo: record.memo
-        }
+        record: build_record_json(record, activity),
+        summary_per_category: summarize_per_activity(logs, now),
+        now: now.iso8601
       }, status: :created
     else
       render json: {
@@ -29,5 +26,40 @@ class Api::DashboardLogsController < ApplicationController
         error: record.errors.full_messages.first || "保存に失敗しました"
       }, status: :unprocessable_entity
     end
+  end
+
+  private
+
+  def build_record_json(record, activity)
+    {
+      id: record.public_id,
+      activity: {
+        id: activity.public_id,
+        name: activity.name
+      },
+      logged_at: record.logged_at.in_time_zone("Tokyo").iso8601,
+      memo: record.memo
+    }
+  end
+
+  def summarize_per_activity(logs, now)
+    return [] if logs.empty?
+    sums = Hash.new { |h, k| h[k] = { total_minutes: 0, count: 0, activity_name: nil } }
+    logs.each_with_index do |log, i|
+      next_time = logs[i + 1]&.logged_at || now
+      diff_minutes = [[((next_time - log.logged_at) / 60).floor, 0].max, 360].min
+      key = log.activity.public_id
+      sums[key][:total_minutes] += diff_minutes
+      sums[key][:count] += 1
+      sums[key][:activity_name] ||= log.activity.name
+    end
+    sums.map do |activity_id, v|
+      {
+        activity_id: activity_id,
+        activity_name: v[:activity_name],
+        total_minutes: v[:total_minutes],
+        count: v[:count]
+      }
+    end.sort_by { |h| -h[:total_minutes] }
   end
 end

--- a/app/javascript/react/dashboard/DashboardApp.jsx
+++ b/app/javascript/react/dashboard/DashboardApp.jsx
@@ -29,9 +29,18 @@ export default function DashboardApp() {
     setError(null);
     try {
       setIsSubmitting(true);
-      await postLog({ activityId, memo });
+      const data = await postLog({ activityId, memo });
+
+      // POSTレスポンスで直接stateを更新（loadAll不要）
+      setDashboard((prev) => ({
+        ...prev,
+        logs: [...(prev?.logs ?? []), data.record],
+        summary_per_category: data.summary_per_category,
+        current_log: data.record,
+        now: data.now,
+      }));
+
       onSuccess?.();
-      await loadAll();
     } catch (e) {
       console.error(e);
       setError(e.message);

--- a/app/javascript/react/dashboard/components/charts/DonutChart.jsx
+++ b/app/javascript/react/dashboard/components/charts/DonutChart.jsx
@@ -32,7 +32,7 @@ export default function DonutChart({ labels, values, colors, size = 160 }) {
     return () => {
       if (chartRef.current) chartRef.current.destroy();
     };
-  }, [labels, values, colors]);
+  }, [labels.join(","), values.join(","), colors.join(",")]);
 
   return <canvas ref={canvasRef} width={size} height={size} />;
 }


### PR DESCRIPTION
## 概要
2つの改善をまとめて対応しました。

---

## 1. 記録後のAPI再取得をPOSTレスポンスで代替しstateを直接更新

### 背景
記録ボタン押下後、これまでは `GET /api/dashboard/today` を再取得していたため、APIコールが計3回発生していました。

### 変更内容

#### `app/controllers/api/dashboard_logs_controller.rb`
POSTのレスポンスに以下を追加：
- `summary_per_category`：更新後のカテゴリ別集計
- `now`：サーバー側の現在時刻

#### `app/javascript/react/dashboard/DashboardApp.jsx`
`handleSubmit` を修正：
- 変更前：`postLog()` → `loadAll()`（GET×2回）
- 変更後：`postLog()` のレスポンスで `dashboard` stateを直接更新（GET不要）

| | 変更前 | 変更後 |
|---|---|---|
| APIコール数 | 3回（POST+GET×2） | 1回（POSTのみ） |
| 画面更新タイミング | GET完了後 | POSTレスポンス受信後 |

---

## 2. DonutChartの二重描画を依存配列の文字列化で修正

### 原因
`useEffect` の依存配列に配列オブジェクトを渡していたため、中身が同じでも毎回「新しい配列」と判定され再実行されていました。

### 変更内容

#### `app/javascript/react/dashboard/components/charts/DonutChart.jsx`
```jsx
// 変更前
}, [labels, values, colors]);

// 変更後
}, [labels.join(","), values.join(","), colors.join(",")]);
```

---

## 動作確認
- [ ] 記録ボタン押下後、ページリロードなしで履歴・サマリー・推定時間が更新される
- [ ] 記録後にAPIが1回しか呼ばれていない（DevTools Networkで確認）
- [ ] 記録ボタン押下後、円グラフが1回だけ描画される