### PR TITLE
計測を止めるボタンを実装・ended_atをDBに保存

### DIFF
--- a/app/controllers/api/dashboard_controller.rb
+++ b/app/controllers/api/dashboard_controller.rb
@@ -14,7 +14,7 @@ class Api::DashboardController < ApplicationController
     render json: {
       logs: build_logs_json(logs),
       summary_per_category: summarize_per_activity(logs, now),
-      current_log: logs.last ? build_record_json(logs.last) : nil,
+      current_log: logs.select { |l| l.ended_at.nil? }.last&.then { |l| build_record_json(l) },
       now: now.iso8601
     }
   end

--- a/app/controllers/api/dashboard_stop_controller.rb
+++ b/app/controllers/api/dashboard_stop_controller.rb
@@ -1,0 +1,19 @@
+class Api::DashboardStopController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    current_log = current_user.records
+                               .where(ended_at: nil)
+                               .order(logged_at: :desc)
+                               .first
+
+    if current_log.nil?
+      render json: { ok: false, error: "計測中の記録がありません" }, status: :unprocessable_entity
+      return
+    end
+
+    current_log.update!(ended_at: Time.current)
+
+    render json: { ok: true }, status: :ok
+  end
+end

--- a/app/javascript/react/dashboard/DashboardApp.jsx
+++ b/app/javascript/react/dashboard/DashboardApp.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { fetchToday, fetchActivities, postLog } from "./api";
 import LogForm from "./components/LogForm";
 import TodayHistory from "./components/TodayHistory";
 import CurrentStatus from "./components/CurrentStatus"; 
 import SummaryStatus from "./components/SummaryStatus";
+import { fetchToday, fetchActivities, postLog, stopLog } from "./api";
 
 export default function DashboardApp() {
   const [dashboard, setDashboard] = useState(null);
@@ -64,6 +64,19 @@ export default function DashboardApp() {
     }
   }
 
+  async function handleStopTimer() {
+    try {
+      await stopLog();
+      setDashboard((prev) => ({
+        ...prev,
+        current_log: null,
+      }));
+    } catch (e) {
+      console.error(e);
+      setError(e.message);
+    }
+  }
+
   const logs = dashboard?.logs ?? [];
 
   return (
@@ -85,7 +98,7 @@ export default function DashboardApp() {
       </div>
 
       {/* 中段：推定時間 */}
-      <CurrentStatus dashboard={dashboard} activities={activities} now={now} />
+      <CurrentStatus dashboard={dashboard} activities={activities} now={now} onStop={handleStopTimer}/>
       
       {/* 下段：今日の履歴 */}
       <TodayHistory logs={logs} activities={activities} />

--- a/app/javascript/react/dashboard/api.js
+++ b/app/javascript/react/dashboard/api.js
@@ -41,3 +41,19 @@ export async function postLog({ activityId, memo }) {
 
   return data;
 }
+
+export async function stopLog() {
+  const res = await fetch("/api/dashboard/stop", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "X-CSRF-Token": csrfToken(),
+    },
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data.ok === false) {
+    throw new Error(data.error || "計測の停止に失敗しました");
+  }
+  return data;
+}

--- a/app/javascript/react/dashboard/components/CurrentStatus.jsx
+++ b/app/javascript/react/dashboard/components/CurrentStatus.jsx
@@ -1,26 +1,24 @@
 import React from "react";
 
-export default function CurrentStatus({ dashboard, activities, now }) {
+export default function CurrentStatus({ dashboard, activities, now, onStop }) {
   const currentLog = dashboard?.current_log ?? null;
   const currentNow = now ?? new Date();
 
   const activity = activities.find((a) => a.id === currentLog?.activity?.id);
   const activityName = activity ? `${activity.icon} ${activity.name}` : "未選択";
 
-  // 経過秒数を計算
   const elapsedSeconds = currentLog
     ? Math.max(0, Math.floor((currentNow - new Date(currentLog.logged_at)) / 1000))
     : 0;
 
-  // 最大6時間（21600秒）
   const cappedSeconds = Math.min(elapsedSeconds, 21600);
   const hours = Math.floor(cappedSeconds / 3600);
   const minutes = Math.floor((cappedSeconds % 3600) / 60);
   const seconds = cappedSeconds % 60;
   const timeStr = currentLog
     ? hours > 0
-        ?  `${hours}時間${minutes}分${seconds}秒`
-        : `${minutes}分${seconds}秒`
+      ? `${hours}時間${minutes}分${seconds}秒`
+      : `${minutes}分${seconds}秒`
     : "0分0秒";
 
   return (
@@ -51,6 +49,35 @@ export default function CurrentStatus({ dashboard, activities, now }) {
             推定経過時間：<span style={{ color: "#4f46e5", fontFamily: "monospace", fontWeight: 700, fontSize: 16 }}>{timeStr}</span>
           </div>
         </div>
+
+        {currentLog && (
+          <button
+            onClick={onStop}
+            style={{
+              padding: "11px 22px",
+              borderRadius: 14,
+              border: "none",
+              background: "linear-gradient(135deg, #fb7185, #f43f5e)",
+              color: "white",
+              fontSize: 13,
+              fontWeight: 800,
+              cursor: "pointer",
+              fontFamily: "inherit",
+              transition: "all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1)",
+              boxShadow: "0 4px 16px rgba(244,63,94,0.3)",
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.transform = "translateY(-2px)";
+              e.currentTarget.style.boxShadow = "0 8px 24px rgba(244,63,94,0.4)";
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.transform = "none";
+              e.currentTarget.style.boxShadow = "0 4px 16px rgba(244,63,94,0.3)";
+            }}
+          >
+            計測を止める
+          </button>
+        )}
       </div>
     </div>
   );

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,5 +25,6 @@ Rails.application.routes.draw do
     get "dashboard/today", to: "dashboard#today"
     get "activities", to: "activities#index"
     post "dashboard/logs", to: "dashboard_logs#create"
+    post "dashboard/stop", to: "dashboard_stop#create"
   end
 end

--- a/db/migrate/20260225090806_add_ended_at_to_records.rb
+++ b/db/migrate/20260225090806_add_ended_at_to_records.rb
@@ -1,0 +1,5 @@
+class AddEndedAtToRecords < ActiveRecord::Migration[7.1]
+  def change
+    add_column :records, :ended_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_02_20_080813) do
+ActiveRecord::Schema[7.1].define(version: 2026_02_25_090806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_20_080813) do
     t.datetime "updated_at", null: false
     t.uuid "public_id", default: -> { "gen_random_uuid()" }, null: false
     t.datetime "logged_at"
+    t.datetime "ended_at"
     t.index ["activity_id"], name: "index_records_on_activity_id"
     t.index ["public_id"], name: "index_records_on_public_id", unique: true
     t.index ["user_id"], name: "index_records_on_user_id"


### PR DESCRIPTION
## 概要
「今日の推定時間」に「計測を止める」ボタンを追加しました。
ボタンを押すと `ended_at` がDBに保存され、リロード後もタイマーが再開しません。

## 変更内容

### DB
- `records` テーブルに `ended_at` カラムを追加（migration: `AddEndedAtToRecords`）

### Rails
#### `config/routes.rb`
- `POST /api/dashboard/stop` を追加

#### `app/controllers/api/dashboard_stop_controller.rb`（新規）
- `ended_at` が `nil` の最新レコードを取得して `ended_at` を保存

#### `app/controllers/api/dashboard_controller.rb`
- `current_log` を `ended_at: nil` のログのみに絞るよう修正

### React
#### `app/javascript/react/dashboard/api.js`
- `stopLog()` 関数を追加（`POST /api/dashboard/stop`）

#### `app/javascript/react/dashboard/DashboardApp.jsx`
- `stopLog` を import
- `handleStopTimer` を追加（`stopLog()` 呼び出し後に `current_log` を `null` に）
- `CurrentStatus` に `onStop` を渡す

#### `app/javascript/react/dashboard/components/CurrentStatus.jsx`
- `onStop` props を追加
- `current_log` がある場合に「計測を止める」ボタンを表示

## 動作確認
- [ ] 「計測を止める」ボタンが表示される
- [ ] ボタンを押すとタイマーが止まる
- [ ] ページをリロードしてもタイマーが再開しない
- [ ] 止めた後に新しい行動を記録するとタイマーが再開する