### PR TITLE
feat: ヘッダー/フッターのデザイン一新・ナビ追加・レスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/shared/_footer.scss
+++ b/app/assets/stylesheets/shared/_footer.scss
@@ -1,17 +1,50 @@
 .footer {
-  width: 100%; // すでにあるが確認
-  padding: 16px 20px;
-  background: #047429;
-  margin: 0; // 追加
-  box-sizing: border-box; // 追加（paddingを含めた幅を100%にする）
+  width: 100%;
+  padding: 16px 24px;
+  background: rgba(15, 23, 42, 0.82);
+  backdrop-filter: blur(20px);
+  border-top: 1px solid rgba(255,255,255,0.08);
+  box-sizing: border-box;
 }
 
-.footer-items {
+.footer-inner {
   display: flex;
-  justify-content: flex-start;
-  gap: 16px;
   align-items: center;
-  color: #fff;
-  max-width: 1200px; // 追加（コンテンツの最大幅を制限）
-  margin: 0 auto; // 追加（中央寄せ）
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.footer-copy {
+  color: rgba(255,255,255,0.6);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.footer-links {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+
+  a {
+    color: rgba(255,255,255,0.55);
+    text-decoration: none;
+    font-size: 12px;
+    font-weight: 600;
+    transition: color 0.15s;
+
+    &:hover { color: white; }
+  }
+}
+
+@media (max-width: 768px) {
+  .footer-inner {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .footer-links { justify-content: center; }
 }

--- a/app/assets/stylesheets/shared/_header.scss
+++ b/app/assets/stylesheets/shared/_header.scss
@@ -1,49 +1,157 @@
 .header {
-  background: #047429;
-  border-bottom: 1px solid #ddd;
-  padding: 1rem 2rem;
+  background: rgba(15, 23, 42, 0.82);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  box-shadow: 0 2px 24px rgba(0,0,0,0.15);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+}
 
-  .header-inner {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
+.header-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
 
-  .header-nav a {
-    margin-left: 1rem;
-    text-decoration: none;
-    color: #fff;
-    font-weight: bold;
-  }
+.logo {
+  flex-shrink: 0;
 
   .logo-img {
-    height: 40px; // 好きなサイズでOK
+    height: 40px;
     display: block;
   }
+}
 
-  .header-nav {
-  .user-info {
-    display: flex;          // 横並びに
-    align-items: center;    // 縦方向中央揃え
-    gap: 1rem;              // メール/ボタン間のスペース
-  }
+.header-nav {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: 1;
+  justify-content: center;
+}
 
-  .username {
-    font-weight: bold;
-    background-color: #edf2f7;
-    color: #2d3748;
-    padding: 0.25rem 0.6rem;
-    border-radius: 12px;
-    font-size: 0.95rem;
-  }
+.nav-link {
+  color: rgba(255,255,255,0.75);
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 700;
+  padding: 6px 14px;
+  border-radius: 20px;
+  transition: all 0.15s;
+  white-space: nowrap;
 
-  .logout-btn {
-    padding: 0.3rem 0.8rem;
-    border-radius: 6px;
-    background-color: #f56565;  // 赤系
+  &:hover {
+    background: rgba(255,255,255,0.12);
     color: white;
-    border: none;
-    cursor: pointer;
+  }
+
+  &.active {
+    background: rgba(255,255,255,0.18);
+    color: white;
   }
 }
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.username {
+  color: white;
+  font-size: 12px;
+  font-weight: 700;
+  background: rgba(255,255,255,0.12);
+  padding: 4px 10px;
+  border-radius: 20px;
+}
+
+.logout-btn {
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1.5px solid rgba(255,255,255,0.35);
+  background: none;
+  color: white;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+
+  &:hover { background: rgba(255,255,255,0.12); }
+}
+
+.hamburger {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  cursor: pointer;
+  padding: 4px;
+  background: none;
+  border: none;
+
+  span {
+    display: block;
+    width: 22px;
+    height: 2px;
+    background: white;
+    border-radius: 2px;
+    transition: all 0.3s;
+  }
+}
+
+.mobile-menu {
+  display: none;
+  background: rgba(15, 23, 42, 0.95);
+  backdrop-filter: blur(20px);
+  padding: 12px 24px 16px;
+  border-top: 1px solid rgba(255,255,255,0.08);
+
+  &.open { display: block; }
+
+  .mobile-link {
+    display: block;
+    color: rgba(255,255,255,0.85);
+    text-decoration: none;
+    font-size: 14px;
+    font-weight: 700;
+    padding: 14px 0;
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+
+    &:last-of-type { border-bottom: none; }
+    &.active { color: white; }
+  }
+
+  .mobile-logout {
+    display: block;
+    width: 100%;
+    text-align: left;
+    background: none;
+    border: none;
+    border-top: 1px solid rgba(255,255,255,0.08);
+    color: rgba(255,255,255,0.7);
+    font-size: 14px;
+    font-weight: 700;
+    padding: 14px 0;
+    cursor: pointer;
+    font-family: inherit;
+
+    &:hover { color: white; }
+  }
+}
+
+@media (max-width: 768px) {
+  .header-nav { display: none; }
+  .username { display: none; }
+  .logout-btn { display: none; }
+  .header-right { display: none; }
+  .hamburger { display: flex; }
 }

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,9 @@
 <footer class="footer">
-  <div class="footer-items">
-    <span>© 2025 Study-keeper</span>
-    <span>利用規約（準備中）</span>
+  <div class="footer-inner">
+    <span class="footer-copy">© 2025 Study-keeper</span>
+    <div class="footer-links">
+      <a href="#">利用規約</a>
+      <a href="#">プライバシーポリシー</a>
+    </div>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,21 +1,53 @@
 <header class="header">
   <div class="header-inner">
     <div class="logo">
-        <%= link_to logo_link_path do %>
-          <%= image_tag "logo.png", alt: "Study-keeper", class: "logo-img" %>
-        <% end %>
-    </div>
-  
-    <div class="header-nav">
-      <% if user_signed_in? %> 
-        <div class="user-info">
-          <span class="username">ユーザー名：<%= current_user.name %></span>
-          <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "logout-btn" %>
-        </div>
-      <% else %>
-        <%= link_to "ログイン", new_user_session_path, class: "login-btn" %>
-        <%= link_to "ユーザー登録", new_user_registration_path, class: "signup-btn" %>
+      <%= link_to logo_link_path do %>
+        <%= image_tag "logo.png", alt: "Study-keeper", class: "logo-img" %>
       <% end %>
     </div>
+
+    <% if user_signed_in? %>
+      <nav class="header-nav">
+        <%= link_to "今日の記録", learning_path, class: "nav-link #{'active' if current_page?(learning_path)}" %>
+        <%= link_to "週次記録", "#", class: "nav-link" %>
+        <%= link_to "カレンダー", "#", class: "nav-link" %>
+        <%= link_to "ユーザー設定", "#", class: "nav-link" %>
+      </nav>
+
+      <div class="header-right">
+        <span class="username"><%= current_user.name %></span>
+        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "logout-btn" %>
+      </div>
+    <% else %>
+      <div class="header-right">
+        <%= link_to "ログイン", new_user_session_path, class: "nav-link" %>
+        <%= link_to "ユーザー登録", new_user_registration_path, class: "nav-link active" %>
+      </div>
+    <% end %>
+
+    <button class="hamburger" id="hamburger" onclick="toggleMenu()">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+  </div>
+
+  <div class="mobile-menu" id="mobileMenu">
+    <% if user_signed_in? %>
+      <%= link_to "今日の記録", learning_path, class: "mobile-link #{'active' if current_page?(learning_path)}" %>
+      <%= link_to "週次記録", "#", class: "mobile-link" %>
+      <%= link_to "カレンダー", "#", class: "mobile-link" %>
+      <%= link_to "ユーザー設定", "#", class: "mobile-link" %>
+      <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "mobile-logout" %>
+    <% else %>
+      <%= link_to "ログイン", new_user_session_path, class: "mobile-link" %>
+      <%= link_to "ユーザー登録", new_user_registration_path, class: "mobile-link" %>
+    <% end %>
   </div>
 </header>
+
+<script>
+function toggleMenu() {
+  document.getElementById('mobileMenu').classList.toggle('open');
+}
+</script>


### PR DESCRIPTION
## 概要
ヘッダー・フッターのデザインを刷新し、レスポンシブ対応を実装しました。
ダークネイビーのすりガラス風デザインでグラデーション背景と馴染むデザインにしています。

## 変更内容

### `app/views/shared/_header.html.erb`
- ダークネイビーのすりガラス風デザインに変更
- ナビゲーションリンクを追加（今日の記録・週次記録・カレンダー・ユーザー設定）
- SP用ハンバーガーメニューを追加
- ログイン/未ログイン両方の表示に対応

### `app/assets/stylesheets/shared/_header.scss`
- `background: rgba(15, 23, 42, 0.82)` + `backdrop-filter: blur(20px)` ですりガラス風に
- PC用ナビ・SP用ハンバーガーメニューのスタイルを追加
- `@media (max-width: 768px)` でレスポンシブ切り替え

### `app/views/shared/_footer.html.erb`
- コピーライト＋リンク横並びレイアウトに変更

### `app/assets/stylesheets/shared/_footer.scss`
- ヘッダーと統一したダークネイビーすりガラス風に変更
- PCは横並び、SPは縦並び中央寄せに対応

## 動作確認
- [ ] PCでナビが横並びに表示される
- [ ] SPでハンバーガーボタンが表示される
- [ ] ハンバーガーを押すとメニューが開閉する
- [ ] ログイン/未ログイン両方の表示が問題ない
- [ ] 375px幅で横スクロールが発生しない
- [ ] フッターがSPで縦並びになる