### PR TITLE
feat: 指定週のログ取得ロジックを実装

### DIFF
--- a/app/controllers/weekly_controller.rb
+++ b/app/controllers/weekly_controller.rb
@@ -2,5 +2,10 @@ class WeeklyController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    base_date = params[:week].present? ? Date.parse(params[:week]) : Date.current
+    @week_start = base_date.beginning_of_week(:monday)
+    @week_end   = base_date.end_of_week(:monday)
+    @logs = current_user.records.in_week(base_date).includes(:activity)
+    Rails.logger.debug "Weekly logs count: #{@logs.count} (#{@week_start} - #{@week_end})"
   end
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -5,6 +5,12 @@ class Record < ApplicationRecord
   validates :activity_id, presence: true
   before_create :set_logged_at
 
+  scope :in_week, ->(date) {
+    start_date = date.beginning_of_week(:monday)
+    end_date   = date.end_of_week(:monday)
+    where(logged_at: start_date.beginning_of_day..end_date.end_of_day)
+  }
+
   def to_param
     public_id
   end


### PR DESCRIPTION
## Summary
- `Record`モデルに`in_week`スコープを追加（月曜始まりで週の範囲を絞り込み）
- `WeeklyController#index`で`week`パラメータを受け取り対象週のログを取得
- `includes(:activity)`でN+1問題を防止

## 関連Issue
closes #110

## Test plan
- [x] `/weekly` にアクセスして今週のログ件数がRailsログに出力されること
- [x] `/weekly?week=2026-02-10` など週を変えると件数が変わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)