### PR TITLE
feat: 週次カテゴリ別サマリ集計サービスを実装

### DIFF
--- a/app/services/weekly_summary_service.rb
+++ b/app/services/weekly_summary_service.rb
@@ -1,0 +1,40 @@
+class WeeklySummaryService
+  MAX_MINUTES = 360
+
+  def initialize(logs)
+    @logs = logs.sort_by(&:logged_at)
+  end
+
+  def call
+    return [] if @logs.empty?
+
+    sums = Hash.new { |h, k| h[k] = { total_minutes: 0, count: 0, activity_name: nil, activity_id: nil } }
+
+    @logs.each_with_index do |log, i|
+      next_log = @logs[i + 1]
+
+      diff_minutes = if next_log && next_log.logged_at.to_date == log.logged_at.to_date
+                       ((next_log.logged_at - log.logged_at) / 60).floor
+                     elsif log.ended_at
+                       ((log.ended_at - log.logged_at) / 60).floor
+                     else
+                       next
+                     end
+
+      diff_minutes = [[diff_minutes, 0].max, MAX_MINUTES].min
+
+      key = log.activity.public_id
+      sums[key][:total_minutes] += diff_minutes
+      sums[key][:count]         += 1
+      sums[key][:activity_name] ||= log.activity.name
+      sums[key][:activity_id]   ||= log.activity.public_id
+    end
+
+    total = sums.values.sum { |v| v[:total_minutes] }
+
+    sums.map do |_, v|
+      percentage = total > 0 ? (v[:total_minutes].to_f / total * 100).round : 0
+      v.merge(percentage: percentage)
+    end.sort_by { |h| -h[:total_minutes] }
+  end
+end


### PR DESCRIPTION
## 概要
- `WeeklySummaryService`を新規作成（`app/services/`）
- ログ間の差分で推定時間を計算（上限360分）
- 日をまたぐ場合は`ended_at`を使用、なければスキップ
- カテゴリ別に`total_minutes`・`count`・`percentage`を集計して返す

## 関連Issue
closes #86

## 動作確認
- [x] Railsコンソールで`WeeklySummaryService.new(logs).call`を実行して集計結果が返ること
- [x] 記録がない場合に空配列が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)