### PR TITLE
feat: 連続記録日数（ストリーク）計算サービスを実装

### DIFF
--- a/app/services/streak_service.rb
+++ b/app/services/streak_service.rb
@@ -1,0 +1,30 @@
+class StreakService
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    recorded_dates = @user.records
+                          .pluck(:logged_at)
+                          .map { |t| t.in_time_zone("Tokyo").to_date }
+                          .uniq
+                          .to_set
+
+    return 0 if recorded_dates.empty?
+
+    # 今日記録があれば今日から、なければ昨日からカウント開始
+    check_date = recorded_dates.include?(Date.current) ? Date.current : Date.current - 1
+
+    # 昨日も記録がなければストリーク0
+    return 0 unless recorded_dates.include?(check_date)
+
+    streak = 0
+    loop do
+      break unless recorded_dates.include?(check_date)
+      streak += 1
+      check_date -= 1
+    end
+
+    streak
+  end
+end


### PR DESCRIPTION
## Summary
- `StreakService`を新規作成（`app/services/`）
- 今日記録があれば今日から、なければ昨日からカウント開始
- 連続が途切れた時点でカウント終了
- 記録が一切ない場合は0を返す

## 関連Issue
closes #91

## Test plan
- [ ] Railsコンソールで`StreakService.new(User.first).call`を実行して数字が返ること
- [ ] 記録がないユーザーで0が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)