### PR TITLE
feat: 週次サマリ用APIを作成

### DIFF
--- a/app/controllers/api/weekly_controller.rb
+++ b/app/controllers/api/weekly_controller.rb
@@ -1,0 +1,23 @@
+class Api::WeeklyController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    base_date  = params[:week].present? ? Date.parse(params[:week]) : Date.current
+    week_start = base_date.beginning_of_week(:monday)
+    week_end   = base_date.end_of_week(:monday)
+
+    logs    = current_user.records.in_week(base_date).includes(:activity).order(:logged_at)
+    summary = WeeklySummaryService.new(logs).call
+    streak  = StreakService.new(current_user).call
+
+    total_minutes = summary.sum { |s| s[:total_minutes] }
+
+    render json: {
+      week_start:    week_start.iso8601,
+      week_end:      week_end.iso8601,
+      total_minutes: total_minutes,
+      summary:       summary,
+      streak_days:   streak
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,5 +28,6 @@ Rails.application.routes.draw do
     get "activities", to: "activities#index"
     post "dashboard/logs", to: "dashboard_logs#create"
     post "dashboard/stop", to: "dashboard_stop#create"
+    get "weekly", to: "weekly#index"
   end
 end


### PR DESCRIPTION
## 概要
- `GET /api/weekly` を追加
- `week`パラメータで対象週を指定（なければ今週）
- `WeeklySummaryService`・`StreakService`を呼び出してJSONで返す
- レスポンス：`week_start`・`week_end`・`total_minutes`・`summary`・`streak_days`

## 関連Issue
closes #111

## 動作確認
- [x] `/api/weekly?week=2026-02-17` にアクセスしてJSONが返ること
- [x] `summary`にカテゴリ別集計が含まれること
- [x] `streak_days`に数値が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)