### PR TITLE
feat: 週ナビゲーション（前の週・次の週）を実装（Issue #113）

### DIFF
--- a/app/javascript/react/weekly/WeeklyApp.jsx
+++ b/app/javascript/react/weekly/WeeklyApp.jsx
@@ -4,12 +4,13 @@ import { fetchWeekly } from "./api";
 export default function WeeklyApp() {
     const [data, setData] = useState(null);
     const [error, setError] = useState(null);
+    const [currentWeekStart, setCurrentWeekStart] = useState(null);
 
     useEffect(() => {
-        fetchWeekly()
+        fetchWeekly(currentWeekStart)
             .then((json) => setData(json))
             .catch((e) => setError(e.message));
-    }, []);
+    }, [currentWeekStart]);
 
     if (error) return <p>{error}</p>
 
@@ -17,6 +18,17 @@ export default function WeeklyApp() {
 
     return (
         <div>
+            <button onClick={() => {
+                const d = new Date(data.week_start);
+                d.setDate(d.getDate() - 7);
+                setCurrentWeekStart(d.toISOString().slice(0, 10));
+            }}>＜ 前の週</button>
+            <p>{data.week_start} ～ {data.week_end}</p>
+            <button onClick={() => {
+                const d = new Date(data.week_start);
+                d.setDate(d.getDate() + 7);
+                setCurrentWeekStart(d.toISOString().slice(0, 10));
+            }}>次の週 ＞</button>
             <p>{data.total_minutes}</p>
         </div>
     )

--- a/app/javascript/react/weekly/api.js
+++ b/app/javascript/react/weekly/api.js
@@ -1,5 +1,6 @@
-export async function fetchWeekly() {
-  const res = await fetch("/api/weekly", {
+export async function fetchWeekly(week = null) {
+  const url = week ? `/api/weekly?week=${week}` : "/api/weekly";
+  const res = await fetch(url, {
     headers: { Accept: "application/json" },
   });
   if (!res.ok) throw new Error("今週のデータ取得に失敗しました");


### PR DESCRIPTION
## 概要
- `api.js` に `week` パラメータを追加（指定週のデータ取得に対応）
- `WeeklyApp.jsx` に `currentWeekStart` state を追加
- 「＜ 前の週」「次の週 ＞」ボタンを実装（クリックで週を切り替え）
- 週の期間（week_start 〜 week_end）を表示

## 動作確認
- [x] 「＜ 前の週」ボタンを押すと1週間前のデータに切り替わることを確認
- [x] 「次の週 ＞」ボタンを押すと1週間後のデータに切り替わることを確認
- [x] 週の期間が正しく表示されることを確認

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)