### PR TITLE
feat: 週次記録画面に円グラフ・サマリを表示（Issue #85）

### DIFF
--- a/app/javascript/react/weekly/WeeklyApp.jsx
+++ b/app/javascript/react/weekly/WeeklyApp.jsx
@@ -1,5 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { fetchWeekly } from "./api";
+import WeeklyChart from "./WeeklyChart";
+
+function formatMinutes(minutes) {
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    return h > 0 ? `${h}時間${m}分` : `${m}分`;
+}
 
 export default function WeeklyApp() {
     const [data, setData] = useState(null);
@@ -29,7 +36,21 @@ export default function WeeklyApp() {
                 d.setDate(d.getDate() + 7);
                 setCurrentWeekStart(d.toISOString().slice(0, 10));
             }}>次の週 ＞</button>
-            <p>{data.total_minutes}</p>
+
+            {data.summary.length === 0 ? (
+                <p>データがありません</p>
+            ):(
+                <WeeklyChart summary={data.summary} />
+            )}
+            <ul>
+                {data.summary.map((s) => (
+                    <li key={s.activity_id}>
+                        {s.activity_name}:{formatMinutes(s.total_minutes)}
+                    </li>
+                ))}
+            </ul>
+            <p>今週の合計：{formatMinutes(data.total_minutes)}</p>
+            <p>🔥 ストリーク：{data.streak_days}日</p>
         </div>
     )
 }

--- a/app/javascript/react/weekly/WeeklyChart.jsx
+++ b/app/javascript/react/weekly/WeeklyChart.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import DonutChart from "../dashboard/components/charts/DonutChart";
+
+const COLORS = ["#818cf8", "#fb923c", "#34d399", "#f43f5e", "#900ce9"];
+
+export default function WeeklyChart({ summary }) {
+    return (
+        <DonutChart
+            labels={summary.map((s) => s.activity_name)}
+            values={summary.map((s) => s.total_minutes)}
+            colors={summary.map((_, i) => COLORS[i % COLORS.length])}
+        />
+    );
+}

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,7 +9,7 @@
     <% if user_signed_in? %>
       <nav class="header-nav">
         <%= link_to "今日の記録", learning_path, class: "nav-link #{'active' if current_page?(learning_path)}" %>
-        <%= link_to "週次記録", "#", class: "nav-link" %>
+        <%= link_to "週次記録", weekly_path, class: "nav-link #{'active' if current_page?(weekly_path)}" %>
         <%= link_to "カレンダー", "#", class: "nav-link" %>
         <%= link_to "ユーザー設定", "#", class: "nav-link" %>
       </nav>


### PR DESCRIPTION
## 概要
- WeeklyChart コンポーネントを作成し、DonutChart を再利用して円グラフを表示
- アクティビティ別の時間リスト（凡例）を表示
- 今週の合計時間・ストリーク日数を表示
- ログがない週は「データがありません」を表示
- ヘッダーの `weekly` → `weekly_path` のバグを修正

## 動作確認
- [ ] `/weekly` に円グラフが表示される
- [ ] グラフ下にアクティビティ別リストが表示される
- [ ] 今週の合計・ストリークが表示される
- [ ] ログのない週に「データがありません」が表示される
- [ ] ヘッダーの「週次記録」リンクが正しく遷移する

Closes #85