### PR TITLE
feat: 週次記録画面にカテゴリ別詳細テーブルを追加（Issue #87）

### DIFF
--- a/app/javascript/react/weekly/WeeklyApp.jsx
+++ b/app/javascript/react/weekly/WeeklyApp.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { fetchWeekly } from "./api";
 import WeeklyChart from "./WeeklyChart";
+import WeeklyTable from "./WeeklyTable";
 
 function formatMinutes(minutes) {
     const h = Math.floor(minutes / 60);
@@ -51,6 +52,8 @@ export default function WeeklyApp() {
             </ul>
             <p>今週の合計：{formatMinutes(data.total_minutes)}</p>
             <p>🔥 ストリーク：{data.streak_days}日</p>
+
+            <WeeklyTable summary={data.summary} formatMinutes={formatMinutes}/>
         </div>
     )
 }

--- a/app/javascript/react/weekly/WeeklyTable.jsx
+++ b/app/javascript/react/weekly/WeeklyTable.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+export default function WeeklyTable({ summary, formatMinutes }) {
+    return (
+        <table>
+            <thead>
+                <tr>
+                    <th>カテゴリ</th>
+                    <th>回数</th>
+                    <th>実施時間</th>
+                    <th>割合</th>
+                    <th>先週比</th>
+                </tr>
+            </thead>
+            <tbody>
+                {summary.map((s) => (
+                    <tr key={s.activity_id}>
+                        <td>{s.activity_name}</td>
+                        <td>{s.count}回</td>
+                        <td>{formatMinutes(s.total_minutes)}</td>
+                        <td>{s.percentage}%</td>
+                        <td>-</td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    );
+}


### PR DESCRIPTION
## 概要
- WeeklyTable コンポーネントを新規作成
- カテゴリ別に回数・実施時間・割合・先週比（ダミー）を表形式で表示
- formatMinutes を props で渡して時間フォーマットを共有

## 動作確認
- [ ] `/weekly` にカテゴリ別詳細テーブルが表示される
- [ ] 各行にカテゴリ名・回数・実施時間・割合が正しく表示される
- [ ] ログがない週はテーブルが表示されない

Closes #87