### PR TITLE
feat: 週次記録画面の基本レイアウトを整える（Issue #88）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -72,6 +72,104 @@ html, body {
   margin-bottom: 14px;
 }
 
+// 週次記録
+.weekly-wrap {
+  padding: 24px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.weekly-nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+
+  button {
+    padding: 6px 16px;
+    border: 1px solid #ccc;
+    border-radius: 20px;
+    background: white;
+    cursor: pointer;
+    font-size: 0.875rem;
+    &:hover { background: #f5f5f5; }
+  }
+
+  span {
+    font-weight: bold;
+    font-size: 1rem;
+  }
+}
+
+.weekly-card {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.weekly-card-title {
+  font-size: 1rem;
+  font-weight: bold;
+  margin-bottom: 16px;
+  color: #444;
+}
+
+.weekly-chart-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+.weekly-legend {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.weekly-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.weekly-legend-color {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.weekly-card table {
+  width: 100%;
+  border-collapse: collapse;
+
+  th, td {
+    padding: 12px 16px;
+    text-align: left;
+    border-bottom: 1px solid #eee;
+  }
+
+  th {
+    font-weight: bold;
+    color: #555;
+    font-size: 0.875rem;
+    background: #f9f9f9;
+  }
+
+  tbody tr:hover {
+    background: #fafafa;
+  }
+}
+
 @media (max-width: 768px) {
   .dashboard-wrap {
     padding: 12px;
@@ -110,4 +208,5 @@ html, body {
       width: 100%;
     }
   }
+
 }

--- a/app/javascript/react/weekly/WeeklyApp.jsx
+++ b/app/javascript/react/weekly/WeeklyApp.jsx
@@ -3,6 +3,8 @@ import { fetchWeekly } from "./api";
 import WeeklyChart from "./WeeklyChart";
 import WeeklyTable from "./WeeklyTable";
 
+const COLORS = ["#818cf8", "#fb923c", "#34d399", "#f43f5e", "#900ce9"];
+
 function formatMinutes(minutes) {
     const h = Math.floor(minutes / 60);
     const m = minutes % 60;
@@ -25,35 +27,46 @@ export default function WeeklyApp() {
     if (data == null) return <p>読み込み中…</p>
 
     return (
-        <div>
-            <button onClick={() => {
-                const d = new Date(data.week_start);
-                d.setDate(d.getDate() - 7);
-                setCurrentWeekStart(d.toISOString().slice(0, 10));
-            }}>＜ 前の週</button>
-            <p>{data.week_start} ～ {data.week_end}</p>
-            <button onClick={() => {
-                const d = new Date(data.week_start);
-                d.setDate(d.getDate() + 7);
-                setCurrentWeekStart(d.toISOString().slice(0, 10));
-            }}>次の週 ＞</button>
+        <div className="weekly-wrap">
+            <div className="weekly-nav">
+                <button onClick={() => {
+                    const d = new Date(data.week_start);
+                    d.setDate(d.getDate() - 7);
+                    setCurrentWeekStart(d.toISOString().slice(0, 10));
+                }}>＜ 前の週</button>
+                <span>{data.week_start} ～ {data.week_end}</span>
+                <button onClick={() => {
+                    const d = new Date(data.week_start);
+                    d.setDate(d.getDate() + 7);
+                    setCurrentWeekStart(d.toISOString().slice(0, 10));
+                }}>次の週 ＞</button>
+            </div>
 
-            {data.summary.length === 0 ? (
-                <p>データがありません</p>
-            ):(
-                <WeeklyChart summary={data.summary} />
-            )}
-            <ul>
-                {data.summary.map((s) => (
-                    <li key={s.activity_id}>
-                        {s.activity_name}:{formatMinutes(s.total_minutes)}
-                    </li>
-                ))}
-            </ul>
-            <p>今週の合計：{formatMinutes(data.total_minutes)}</p>
-            <p>🔥 ストリーク：{data.streak_days}日</p>
+            <div className="weekly-card">
+                <div className="weekly-chart-area">
+                    {data.summary.length === 0 ? (
+                        <p>データがありません</p>
+                    ):(
+                        <WeeklyChart summary={data.summary} />
+                    )}
+                    <p className="weekly-card-title">今週の勉強時間の割合</p>
+                    <ul className="weekly-legend">
+                        {data.summary.map((s, i) => (
+                            <li key={s.activity_id} className="weekly-legend-item">
+                                <span className="weekly-legend-color" style={{ backgroundColor: COLORS[i % COLORS.length] }}></span>
+                                {s.activity_name}：{formatMinutes(s.total_minutes)}
+                            </li>
+                        ))}
+                    </ul>
+                    <p>● 今週の合計：{formatMinutes(data.total_minutes)}</p>
+                    <p>🔥 ストリーク：{data.streak_days}日</p>
+                </div>
+            </div>
 
-            <WeeklyTable summary={data.summary} formatMinutes={formatMinutes}/>
+            <div className="weekly-card">
+                <p className="weekly-card-title">カテゴリ別詳細（表形式）</p>
+                <WeeklyTable summary={data.summary} formatMinutes={formatMinutes}/>
+            </div>
         </div>
     )
 }

--- a/app/javascript/react/weekly/WeeklyChart.jsx
+++ b/app/javascript/react/weekly/WeeklyChart.jsx
@@ -9,6 +9,7 @@ export default function WeeklyChart({ summary }) {
             labels={summary.map((s) => s.activity_name)}
             values={summary.map((s) => s.total_minutes)}
             colors={summary.map((_, i) => COLORS[i % COLORS.length])}
+            size={240}
         />
     );
 }


### PR DESCRIPTION
## 概要
- weekly-wrap で中央寄せ・縦並びレイアウトを実装
- weekly-nav でナビゲーションボタンを横並びに
- weekly-card でグラフ・テーブルをカード形式に（白背景・角丸・影）
- 凡例に色付き■を追加
- テーブルのスタイルを整備（ヘッダー背景・行ホバー）
- DonutChart のサイズを 240px に拡大

## 動作確認
- [ ] PC画面で中央寄せレイアウトで表示される
- [ ] ナビゲーションが横並びで表示される
- [ ] グラフ・テーブルがカード形式で表示される
- [ ] 凡例に色■が表示される

Closes #88
