### PR TITLE
feat: 週次記録画面にXシェアボタンを実装する（Issue #117）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -170,6 +170,21 @@ html, body {
   }
 }
 
+.weekly-share-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 20px;
+  background: #000;
+  color: #fff;
+  border: none;
+  border-radius: 20px;
+  font-size: 0.875rem;
+  font-weight: bold;
+  cursor: pointer;
+  &:hover {background: #333;}
+}
+
 @media (max-width: 768px) {
   .dashboard-wrap {
     padding: 12px;

--- a/app/javascript/react/weekly/WeeklyApp.jsx
+++ b/app/javascript/react/weekly/WeeklyApp.jsx
@@ -11,6 +11,14 @@ function formatMinutes(minutes) {
     return h > 0 ? `${h}時間${m}分` : `${m}分`;
 }
 
+function buildWeeklyShareText(data) {
+    const total = formatMinutes(data.total_minutes);
+    const top = data.summary.slice(0,3)
+        .map((s) => `${s.activity_name}：${formatMinutes(s.total_minutes)}（${s.percentage}%）`)
+        .join("\n");
+    return `今週（${data.week_start} ～ ${data.week_end}）の勉強記録\n合計：${total}\n${top}\nストリーク：${data.streak_days}日\n#StudyKeeper\n`;
+}
+
 export default function WeeklyApp() {
     const [data, setData] = useState(null);
     const [error, setError] = useState(null);
@@ -60,6 +68,13 @@ export default function WeeklyApp() {
                     </ul>
                     <p>● 今週の合計：{formatMinutes(data.total_minutes)}</p>
                     <p>🔥 ストリーク：{data.streak_days}日</p>
+
+                    <button className="weekly-share-btn" onClick={() => {
+                        const text = buildWeeklyShareText(data);
+                        const shareUrl = `${window.location.origin}/weekly?week=${data.week_start}`;
+                        const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(shareUrl)}`;
+                        window.open(url, "_blank");
+                    }}>𝕏 シェアする</button>
                 </div>
             </div>
 


### PR DESCRIPTION
## 概要
- `buildWeeklyShareText(data)` 関数で週の期間・合計時間・上位カテゴリ・ストリークを含む投稿文を自動生成
- ボタンクリックでTwitter intent URLを新タブで開く
- `.weekly-share-btn` クラスでXブランドカラー（黒背景・白文字）のスタイルを適用

## 動作確認
- [ ] 「𝕏 シェアする」ボタンを押すとXの投稿画面が新タブで開く
- [ ] 投稿文に表示中の週の内容（期間・合計・カテゴリ・ストリーク）が反映されている
- [ ] 前の週・次の週に移動後もその週の内容でシェアできる
- [ ] ボタンのデザインが崩れない

Closes #117