### PR TITLE
feat: 週次記録画面のSPレスポンシブ対応（Issue #118）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -225,3 +225,33 @@ html, body {
   }
 
 }
+
+@media (max-width: 576px) {
+  .weekly-wrap {
+    padding: 16px;
+  }
+
+  .weekly-nav {
+    gap: 8px;
+
+    button {
+      padding: 4px 10px;
+      font-size: 0.75rem;
+    }
+
+    span {
+      white-space: nowrap;
+      font-size: 0.8rem;
+    }
+  }
+
+  .weekly-card {
+    overflow-x: auto;
+  }
+
+  .weekly-card table {
+    th, td {
+      white-space: nowrap;
+    }
+  }
+}

--- a/app/javascript/react/weekly/WeeklyApp.jsx
+++ b/app/javascript/react/weekly/WeeklyApp.jsx
@@ -36,7 +36,7 @@ export default function WeeklyApp() {
 
     return (
         <div className="weekly-wrap">
-            <div className="weekly-nav">
+            <div className="weekly-nav mb-3">
                 <button onClick={() => {
                     const d = new Date(data.week_start);
                     d.setDate(d.getDate() - 7);


### PR DESCRIPTION
## 概要
- SPで横スクロールが発生しないようパディングを調整
- ナビの週移動ボタン・日付を小さくして1行に収める
- テーブルカードに `overflow-x: auto` を設定し横スクロール対応
- テーブルのセルに `white-space: nowrap` を追加して文字折り返しを防止

## 動作確認
- [ ] 幅375pxで横スクロールが発生しない
- [ ] 週移動ナビが1行に収まっている
- [ ] テーブルが横スクロールで全列見える
- [ ] PCのレイアウトが崩れていない

Closes #118