### PR TITLE
feat: 月次記録画面の指定月ログ取得を実装する（Issue #93）

### DIFF
--- a/app/controllers/monthly_controller.rb
+++ b/app/controllers/monthly_controller.rb
@@ -2,5 +2,9 @@ class MonthlyController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    base_date = params[:month].present? ? Date.parse("#{params[:month]}-01") : Date.current
+    @month_start = base_date.beginning_of_month
+    @month_end = base_date.end_of_month
+    @monthly_logs = current_user.records.where(logged_at: @month_start.beginning_of_day..@month_end.end_of_day).includes(:activity)
   end
 end


### PR DESCRIPTION
## 概要
- `month` パラメータ（例：`2026-02`）を受け取り対象月を決定
- パラメータなしの場合は今月を対象にする
- `logged_at` カラムで対象月の開始〜終了日時に絞り込み
- `@monthly_logs` にログインユーザーの対象月ログを格納

## 動作確認
- [ ] `/monthly` にアクセスしてエラーが出ない
- [ ] `/monthly?month=2026-02` にアクセスしてエラーが出ない

Closes #93