### PR TITLE
feat: 月次記録画面の日別サマリ集計を実装する（Issue #94）

### DIFF
--- a/app/controllers/monthly_controller.rb
+++ b/app/controllers/monthly_controller.rb
@@ -6,5 +6,17 @@ class MonthlyController < ApplicationController
     @month_start = base_date.beginning_of_month
     @month_end = base_date.end_of_month
     @monthly_logs = current_user.records.where(logged_at: @month_start.beginning_of_day..@month_end.end_of_day).includes(:activity)
+  
+    @daily_summaries = {}
+    @monthly_logs.group_by { |log| log.logged_at.to_date }.each do |date, logs|
+      summary = WeeklySummaryService.new(logs).call
+      next if summary.empty?
+      dominant = summary.first
+      @daily_summaries[date] = {
+        dominant_category: dominant[:activity_name],
+        total_minutes: summary.sum { |s| s[:total_minutes] },
+        per_category: summary
+      }
+    end
   end
 end


### PR DESCRIPTION
## 概要
- `@monthly_logs` を `group_by` で日付ごとにグループ化
- 各日のログに `WeeklySummaryService` を適用して集計
- `@daily_summaries[date]` に支配カテゴリ・合計時間・カテゴリ別詳細を格納
- ログがない日はデータが入らない（エラーなし）

## 動作確認
- [ ] `/monthly` にアクセスしてエラーが出ない
- [ ] ログがない月でもエラーにならない

Closes #94