### PR TITLE
feat: 月次カレンダーに日付クリックでモーダルを表示する（Issue #97）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -359,3 +359,33 @@ html, body {
   font-size: 0.75rem;
   color: #ccc;
 }
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  min-width: 320px;
+  position: relative;
+}
+
+.modal-close {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+  color: #888;
+  &:hover { color: #333; }
+}

--- a/app/javascript/react/monthly/DailyArchiveModal.jsx
+++ b/app/javascript/react/monthly/DailyArchiveModal.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export default function DailyArchiveModal({ date, onClose }) {
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <button className="modal-close" onClick={onClose}>×</button>
+                <h2>{date}</h2>
+                <p>（ここに詳細を表示予定）</p>
+            </div>
+        </div>
+    );
+}

--- a/app/javascript/react/monthly/MonthlyApp.jsx
+++ b/app/javascript/react/monthly/MonthlyApp.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import DailyArchiveModal from "./DailyArchiveModal";
 
 function buildCalendarDays(monthStart, monthEnd) {
     const days = [];
@@ -23,6 +24,7 @@ export default function MonthlyApp() {
     const [data, setData] = useState(null);
     const [error, setError] = useState(null);
     const [currentMonth, setCurrentMonth] = useState(null);
+    const [selectedDate, setSelectedDate] = useState(null);
 
     useEffect(() => {
         const param = currentMonth ? `?month=${currentMonth}` : "";
@@ -56,38 +58,45 @@ export default function MonthlyApp() {
             </div>
 
             <div className="monthly-card">
-            <div className="monthly-calendar">
-                {["月", "火", "水", "木", "金", "土", "日"].map((d) => (
-                    <div key={d} className="monthly-day-header">{d}</div>
-                ))}
-                {days.map((date, i) => {
-                    if (!date) return <div key={`empty-${i}`} className="monthly-day empty"></div>;
-                    const summary = data.daily_summaries[date];
-                    const isToday = date === today;
-                    const dow = new Date(date).getUTCDay();
-                    const isSat = dow === 6;
-                    const isSun = dow === 0;
-                    const hasLog = !!summary;
-                    const classes = [
-                        "monthly-day",
-                        isToday ? "today" : "",
-                        isSat ? "saturday" : "",
-                        isSun ? "sunday" : "",
-                        hasLog ? "has-log" : "",
-                    ].filter(Boolean).join(" ");
-                    return (
-                        <div key={date} className={classes}>
-                            <span className="monthly-day-num">{parseInt(date.slice(8))}</span>
-                            {summary ? (
-                                <span className="monthly-day-category">{summary.dominant_category}</span>
-                            ) : (
-                                <span className="monthly-day-empty">-</span>
-                            )}
-                        </div>
-                    );
-                })}
+                <div className="monthly-calendar">
+                    {["月", "火", "水", "木", "金", "土", "日"].map((d) => (
+                        <div key={d} className="monthly-day-header">{d}</div>
+                    ))}
+                    {days.map((date, i) => {
+                        if (!date) return <div key={`empty-${i}`} className="monthly-day empty"></div>;
+                        const summary = data.daily_summaries[date];
+                        const isToday = date === today;
+                        const dow = new Date(date).getUTCDay();
+                        const isSat = dow === 6;
+                        const isSun = dow === 0;
+                        const hasLog = !!summary;
+                        const classes = [
+                            "monthly-day",
+                            isToday ? "today" : "",
+                            isSat ? "saturday" : "",
+                            isSun ? "sunday" : "",
+                            hasLog ? "has-log" : "",
+                        ].filter(Boolean).join(" ");
+                        return (
+                            <div key={date} className={classes} onClick={() => setSelectedDate(date)}>
+                                <span className="monthly-day-num">{parseInt(date.slice(8))}</span>
+                                {summary ? (
+                                    <span className="monthly-day-category">{summary.dominant_category}</span>
+                                ) : (
+                                    <span className="monthly-day-empty">-</span>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
             </div>
-            </div>
+
+            {selectedDate && (
+                <DailyArchiveModal
+                    date={selectedDate}
+                    onClose={() => setSelectedDate(null)}
+                />
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## 概要
- `MonthlyApp` に `selectedDate` stateを追加
- 日付マスクリックで `selectedDate` にセット、モーダルを表示
- `DailyArchiveModal` コンポーネントを新規作成（ダミー表示）
- 背景クリックまたは×ボタンでモーダルを閉じる
- モーダルのSCSSスタイル追加

## 動作確認
- [ ] 日付マスをクリックするとモーダルが開く
- [ ] ×ボタンでモーダルが閉じる
- [ ] 背景クリックでモーダルが閉じる

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)