### PR TITLE
feat: 1日アーカイブモーダル用のデータ取得APIを実装する（Issue #98）

### DIFF
--- a/app/controllers/api/days_controller.rb
+++ b/app/controllers/api/days_controller.rb
@@ -1,0 +1,21 @@
+class Api::DaysController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    date = Date.parse(params[:date])
+    logs = current_user.records
+                       .where(logged_at: date.beginning_of_day..date.end_of_day)
+                       .includes(:activity)
+
+    summary = WeeklySummaryService.new(logs).call
+
+    render json: {
+      date: date.iso8601,
+      total_minutes: summary.sum { |s| s[:total_minutes] },
+      per_category: summary.map { |s| { name: s[:activity_name], minutes: s[:total_minutes], ratio: s[:percentage] } },
+      logs: logs.map { |log| { activity_name: log.activity.name, logged_at: log.logged_at, ended_at: log.ended_at } }
+    }
+  rescue ArgumentError
+    render json: { error: "不正な日付です" }, status: :bad_request
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,5 +31,6 @@ Rails.application.routes.draw do
     post "dashboard/stop", to: "dashboard_stop#create"
     get "weekly", to: "weekly#index"
     get "monthly", to: "monthly#index"
+    get "days/:date", to: "days#show"
   end
 end


### PR DESCRIPTION
## 概要
- `GET /api/days/:date` ルーティング追加
- `Api::DaysController#show` を新規作成
- 指定日のログを取得し `WeeklySummaryService` でカテゴリ別集計
- `date` / `total_minutes` / `per_category` / `logs` をJSONで返す
- 不正な日付は400エラーを返す

## 動作確認
- [ ] `/api/days/2026-02-17` にアクセスしてJSONが返る
- [ ] ログがない日は空データが返る
- [ ] 不正な日付（例：`/api/days/invalid`）は400が返る

Closes #98