### PR TITLE
feat: 1日アーカイブモーダルのUIを実装する（Issue #99）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -389,3 +389,97 @@ html, body {
   color: #888;
   &:hover { color: #333; }
 }
+
+.daily-modal {
+  min-width: 560px;
+  max-width: 800px;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+
+.daily-modal-title {
+  font-size: 1.1rem;
+  font-weight: bold;
+  margin-bottom: 16px;
+  color: #444;
+}
+
+.daily-modal-empty {
+  color: #aaa;
+  text-align: center;
+  padding: 24px 0;
+}
+
+.daily-modal-body {
+  display: flex;
+  gap: 24px;
+}
+
+.daily-modal-left {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 200px;
+}
+
+.daily-modal-total {
+  font-size: 0.875rem;
+  font-weight: bold;
+}
+
+.daily-modal-legend {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.8rem;
+  }
+}
+
+.daily-modal-color {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.daily-modal-right {
+  flex: 1;
+}
+
+.daily-modal-section-title {
+  font-size: 0.875rem;
+  font-weight: bold;
+  color: #555;
+  margin-bottom: 8px;
+}
+
+.daily-modal-logs {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  li {
+    font-size: 0.8rem;
+    display: flex;
+    gap: 8px;
+  }
+}
+
+.daily-modal-log-time {
+  color: #888;
+  flex-shrink: 0;
+}

--- a/app/javascript/react/monthly/DailyArchiveModal.jsx
+++ b/app/javascript/react/monthly/DailyArchiveModal.jsx
@@ -1,12 +1,89 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import DonutChart from "../dashboard/components/charts/DonutChart";
+
+const COLORS = ["#818cf8", "#fb923c", "#34d399", "#f43f5e", "#900ce9"];
+
+const DAY_NAMES = ["日", "月", "火", "水", "木", "金", "土"];
+
+function formatMinutes(minutes) {
+    const h = Math.floor(minutes / 60);
+    const m = minutes % 60;
+    return h > 0 ? `${h}時間${m}分` : `${m}分`;
+}
+
+function formatDateHeader(dateStr) {
+    const d = new Date(dateStr);
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(d.getUTCDate()).padStart(2, "0");
+    const dow = DAY_NAMES[d.getUTCDay()];
+    return `${y}/${m}/${day}（${dow}）`;
+}
+
+function formatTime(isoString) {
+    const d = new Date(isoString);
+    const h = String(d.getHours()).padStart(2, "0");
+    const m = String(d.getMinutes()).padStart(2, "0");
+    return `${h}:${m}`;
+}
 
 export default function DailyArchiveModal({ date, onClose }) {
+    const [data, setData] = useState(null);
+    const [error, setError] = useState(null);
+
+    useEffect(() => {
+        fetch(`/api/days/${date}`, { headers: { "X-Requested-With": "XMLHttpRequest" } })
+            .then((r) => r.json())
+            .then((json) => setData(json))
+            .catch((e) => setError(e.message));
+    }, [date]);
+
     return (
         <div className="modal-overlay" onClick={onClose}>
-            <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-content daily-modal" onClick={(e) => e.stopPropagation()}>
                 <button className="modal-close" onClick={onClose}>×</button>
-                <h2>{date}</h2>
-                <p>（ここに詳細を表示予定）</p>
+                <h2 className="daily-modal-title">{formatDateHeader(date)}</h2>
+
+                {error && <p>エラーが発生しました</p>}
+                {!data && !error && <p>読み込み中…</p>}
+
+                {data && data.total_minutes === 0 && (
+                    <p className="daily-modal-empty">この日は記録がありません</p>
+                )}
+
+                {data && data.total_minutes > 0 && (
+                    <div className="daily-modal-body">
+                        <div className="daily-modal-left">
+                            <DonutChart
+                                labels={data.per_category.map((c) => c.name)}
+                                values={data.per_category.map((c) => c.minutes)}
+                                colors={data.per_category.map((_, i) => COLORS[i % COLORS.length])}
+                                size={180}
+                            />
+                            <p className="daily-modal-total">合計：{formatMinutes(data.total_minutes)}</p>
+                            <ul className="daily-modal-legend">
+                                {data.per_category.filter((c) => c.minutes > 0).map((c, i) => (
+                                    <li key={c.name}>
+                                        <span className="daily-modal-color" style={{ backgroundColor: COLORS[i % COLORS.length] }}></span>
+                                        {c.name}：{formatMinutes(c.minutes)}
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+
+                        <div className="daily-modal-right">
+                            <p className="daily-modal-section-title">今日の行動履歴</p>
+                            <ul className="daily-modal-logs">
+                                {data.logs.map((log, i) => (
+                                    <li key={i}>
+                                        <span className="daily-modal-log-time">{formatTime(log.logged_at)}</span>
+                                        {log.activity_name}
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    </div>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
## 概要
- `DailyArchiveModal` に `useEffect` でAPIデータ取得を追加
- 日付ヘッダーを `2026/03/05（木）` 形式でフォーマット
- 円グラフ（DonutChart再利用）+ カテゴリ別時間を左側に表示
- 行動履歴リスト（時刻 + アクティビティ名）を右側に表示
- ローディング・エラー・記録なしの3パターン表示対応
- モーダル内スタイルをSCSSに追加

## 動作確認
- [ ] カレンダーの日付をクリックするとモーダルが開く
- [ ] ログがある日は円グラフ・カテゴリ・履歴が表示される
- [ ] ログがない日は「この日は記録がありません」が表示される

Closes #99