### PR TITLE
feat: 日別アーカイブモーダルに共有ボタンを配置する（Issue #166）

### DIFF
--- a/app/javascript/react/monthly/DailyArchiveModal.jsx
+++ b/app/javascript/react/monthly/DailyArchiveModal.jsx
@@ -69,6 +69,12 @@ export default function DailyArchiveModal({ date, onClose }) {
                                     </li>
                                 ))}
                             </ul>
+                            <button
+                                className="weekly-share-btn mt-2"
+                                onClick={() => console.log("share clicked", date)}
+                            >
+                                𝕏 シェアする
+                            </button>    
                         </div>
 
                         <div className="daily-modal-right">


### PR DESCRIPTION
## 概要
- `DailyArchiveModal` の円グラフ下に「𝕏 シェアする」ボタンを追加
- クリック時に `console.log` で仮ハンドラを設定

## 動作確認
- [ ] モーダルを開くと共有ボタンが表示される
- [ ] ボタンを押すとコンソールにログが出る

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)