### PR TITLE
feat: 日別共有文を生成する関数を作成する（Issue #169）

### DIFF
--- a/app/javascript/react/monthly/DailyArchiveModal.jsx
+++ b/app/javascript/react/monthly/DailyArchiveModal.jsx
@@ -27,6 +27,17 @@ function formatTime(isoString) {
     return `${h}:${m}`;
 }
 
+function buildDailyShareText(date, data) {
+    if(!data || data.total_minutes === 0) return `${date}の記録はありませんでした\nStudyKeeper\n`;
+    const total = formatMinutes(data.total_minutes);
+    const top = data.per_category
+        .filter((c) => c.minutes > 0)
+        .slice(0, 3)
+        .map((c) => `${c.name} : ${formatMinutes(c.minutes)}`)
+        .join("\n");
+    return `${formatDateHeader(date)}の活動記録\n合計：${total}\n${top}\n#StudyKeeper\n`;
+}
+
 export default function DailyArchiveModal({ date, onClose }) {
     const [data, setData] = useState(null);
     const [error, setError] = useState(null);
@@ -71,7 +82,12 @@ export default function DailyArchiveModal({ date, onClose }) {
                             </ul>
                             <button
                                 className="weekly-share-btn mt-2"
-                                onClick={() => console.log("share clicked", date)}
+                                onClick={() => {
+                                    const text = buildDailyShareText(date, data);
+                                    const shareUrl = `${window.location.origin}/monthly`;
+                                    const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(shareUrl)}`;
+                                    window.open(url, "_blank");
+                                }}
                             >
                                 𝕏 シェアする
                             </button>    


### PR DESCRIPTION
## 概要
- `buildDailyShareText(date, data)` 関数を追加
- 日付・合計時間・上位3カテゴリを含む共有文を生成
- シェアボタンのonClickをconsole.logから実際のX intent URLに変更
- データがない日でも壊れない実装

## 動作確認
- [ ] モーダルのシェアボタンを押すとXの投稿画面が開く
- [ ] 投稿文にその日の記録内容が入っている
- [ ] ログがない日でもエラーにならない

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)