### PR TITLE
feat: 月次記録画面のSPレイアウトを整理する（Issue #124）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -266,6 +266,25 @@ html, body {
   gap: 16px;
 }
 
+@media (max-width: 576px) {
+  .monthly-wrap {
+    padding: 8px 4px;
+  }
+
+  .monthly-day {
+    padding: 4px;
+    min-height: 48px;
+  }
+
+  .monthly-day-num {
+    font-size: 0.7rem;
+  }
+
+  .monthly-calendar {
+    gap: 2px;  // ← マス間の隙間を狭く
+  }
+}
+
 .monthly-nav {
   display: flex;
   align-items: center;
@@ -352,7 +371,10 @@ html, body {
 .monthly-day-category {
   font-size: 0.7rem;
   color: #818cf8;
-  word-break: break-all;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
 }
 
 .monthly-day-empty {


### PR DESCRIPTION
## 概要
- カテゴリ名が縦に折り返さないよう `text-overflow: ellipsis` を適用
- SP時のパディング・マス間隔を縮小してカレンダーを見やすく調整

## 動作確認
- [ ] 幅375pxで横スクロールが出ない
- [ ] カテゴリ名が折り返さずに省略表示される
- [ ] PCのレイアウトが崩れない

Closes #124