### PR TITLE
feat: 月次記録画面の年月ナビゲーションをSP向けに整える（Issue #125）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -283,6 +283,13 @@ html, body {
   .monthly-calendar {
     gap: 2px;  // ← マス間の隙間を狭く
   }
+
+  .monthly-nav {
+    button {
+      padding: 8px 16px;
+      font-size: 0.875rem;
+    }
+  }
 }
 
 .monthly-nav {


### PR DESCRIPTION
## 概要
- SPでナビゲーションボタンのパディングを大きくしてタップしやすく調整

## 動作確認
- [ ] SPで前月・次月ボタンが押しやすい
- [ ] PCのレイアウトが崩れない

Closes #125