### PR TITLE
feat: 月次カレンダーをSP幅に収める（Issue #126）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -274,6 +274,7 @@ html, body {
   .monthly-day {
     padding: 4px;
     min-height: 48px;
+    min-width: 0; 
   }
 
   .monthly-day-num {
@@ -289,6 +290,15 @@ html, body {
       padding: 8px 16px;
       font-size: 0.875rem;
     }
+  }
+
+  .monthly-card {
+    padding: 12px 8px;
+  }
+
+  .monthly-day-category,
+  .monthly-day-empty {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## 概要
- `.monthly-day` に `min-width: 0` を追加してグリッドの列幅崩れを修正
- SP時にカテゴリ名・「-」を非表示にして日付のみのシンプル表示に
- ログがある日は紫背景で判別できるため情報量は維持

## 動作確認
- [ ] SPで7列が収まり横スクロールが出ない
- [ ] ログがある日は紫背景で表示される
- [ ] PCではカテゴリ名が表示される

Closes #126