### PR TITLE
feat: 月次カレンダーに支配カテゴリのアイコンを表示する（Issue #127）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -296,7 +296,7 @@ html, body {
     padding: 12px 8px;
   }
 
-  .monthly-day-category,
+  .monthly-day-category span:last-child,
   .monthly-day-empty {
     display: none;
   }
@@ -386,6 +386,9 @@ html, body {
 }
 
 .monthly-day-category {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   font-size: 0.7rem;
   color: #818cf8;
   overflow: hidden;

--- a/app/controllers/api/monthly_controller.rb
+++ b/app/controllers/api/monthly_controller.rb
@@ -14,6 +14,7 @@ class Api::MonthlyController < ApplicationController
       next if summary.empty?
       daily_summaries[date.iso8601] = {
         dominant_category: summary.first[:activity_name],
+        dominant_icon: summary.first[:icon],
         total_minutes: summary.sum { |s| s[:total_minutes]},
         per_category: summary
       }

--- a/app/javascript/react/monthly/MonthlyApp.jsx
+++ b/app/javascript/react/monthly/MonthlyApp.jsx
@@ -81,7 +81,10 @@ export default function MonthlyApp() {
                             <div key={date} className={classes} onClick={() => setSelectedDate(date)}>
                                 <span className="monthly-day-num">{parseInt(date.slice(8))}</span>
                                 {summary ? (
-                                    <span className="monthly-day-category">{summary.dominant_category}</span>
+                                    <span className="monthly-day-category">
+                                        <span>{summary.dominant_icon}</span>
+                                        <span>{summary.dominant_category}</span>
+                                    </span>
                                 ) : (
                                     <span className="monthly-day-empty">-</span>
                                 )}

--- a/app/services/weekly_summary_service.rb
+++ b/app/services/weekly_summary_service.rb
@@ -28,6 +28,7 @@ class WeeklySummaryService
       sums[key][:count]         += 1
       sums[key][:activity_name] ||= log.activity.name
       sums[key][:activity_id]   ||= log.activity.public_id
+      sums[key][:icon] ||= log.activity.icon
     end
 
     total = sums.values.sum { |v| v[:total_minutes] }


### PR DESCRIPTION
## 概要
- `WeeklySummaryService` に `icon` カラムを追加
- `Api::MonthlyController` に `dominant_icon` を追加
- `MonthlyApp.jsx` でアイコン＋カテゴリ名を縦並びで表示
- SP時はアイコンのみ表示、カテゴリ名は非表示

## 動作確認
- [ ] PCでカレンダーにアイコンとカテゴリ名が表示される
- [ ] SPでアイコンのみ表示される
- [ ] ログがない日は何も表示されない

Closes #127