### PR TITLE
feat: 月次カレンダーのタップ領域とデザインを改善する（Issue #128）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -273,7 +273,7 @@ html, body {
 
   .monthly-day {
     padding: 4px;
-    min-height: 48px;
+    min-height: 52px;
     min-width: 0; 
   }
 
@@ -316,6 +316,7 @@ html, body {
     cursor: pointer;
     font-size: 0.875rem;
     &:hover { background: #f5f5f5; }
+    &:active { transform: scale(0.95); }
   }
 
   span {
@@ -357,22 +358,38 @@ html, body {
   min-height: 64px;
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 4px;
   box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+  cursor: pointer;
+  min-width: 0;
+
+  &:active {
+    opacity: 0.7;
+    transform: scale(0.97);
+  }
 
   &.empty {
     background: transparent;
     box-shadow: none;
+    cursor: default;
   }
 
   &.today {
-    border: 2px solid #818cf8;
-    background: #eef2ff;
+    background: #e0e7ff;
+    border: 2px solid #4f46e5;
+
+    .monthly-day-num { color: #4f46e5; }
   }
 
   &.has-log {
     background: linear-gradient(135deg, #ede9fe, #fff);
     border: 1px solid #c4b5fd;
+  }
+
+  &.today.has-log {
+    background: #3730a3;
+    border: none;
   }
 
   &.saturday .monthly-day-num { color: #3b82f6; }
@@ -523,5 +540,12 @@ html, body {
 
 .daily-modal-log-time {
   color: #888;
+  flex-shrink: 0;
+}
+
+.monthly-day-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
   flex-shrink: 0;
 }

--- a/app/javascript/react/monthly/MonthlyApp.jsx
+++ b/app/javascript/react/monthly/MonthlyApp.jsx
@@ -81,13 +81,8 @@ export default function MonthlyApp() {
                             <div key={date} className={classes} onClick={() => setSelectedDate(date)}>
                                 <span className="monthly-day-num">{parseInt(date.slice(8))}</span>
                                 {summary ? (
-                                    <span className="monthly-day-category">
-                                        <span>{summary.dominant_icon}</span>
-                                        <span>{summary.dominant_category}</span>
-                                    </span>
-                                ) : (
-                                    <span className="monthly-day-empty">-</span>
-                                )}
+                                    <span className="monthly-day-icon">{summary.dominant_icon}</span>
+                                ) : null}
                             </div>
                         );
                     })}


### PR DESCRIPTION
## 概要
- セルに `cursor: pointer` と `:active` スタイルを追加してタップフィードバックを実装
- 今日の日付を薄い紫背景＋ボーダーで強調表示
- ログがある日のカテゴリをドットからアイコン表示に変更
- ナビボタンに `:active` スタイルを追加

## 動作確認
- [ ] 日付セルをタップするとモーダルが開く
- [ ] 今日の日付が見やすく表示される
- [ ] ログがある日にアイコンが表示される

Closes #128