### PR TITLE
feat: 日別共有URLに日付パラメータを追加する（Issue #168）

### DIFF
--- a/app/javascript/react/monthly/DailyArchiveModal.jsx
+++ b/app/javascript/react/monthly/DailyArchiveModal.jsx
@@ -84,7 +84,7 @@ export default function DailyArchiveModal({ date, onClose }) {
                                 className="weekly-share-btn mt-2"
                                 onClick={() => {
                                     const text = buildDailyShareText(date, data);
-                                    const shareUrl = `${window.location.origin}/monthly`;
+                                    const shareUrl = `${window.location.origin}/monthly?date=${date}`;
                                     const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(shareUrl)}`;
                                     window.open(url, "_blank");
                                 }}


### PR DESCRIPTION
## 概要
- 共有URLを `/monthly` から `/monthly?date=YYYY-MM-DD` に変更
- 表示中の日付に応じたURLが生成される

## 動作確認
- [ ] シェアボタンを押すとURLに `?date=` が付いている

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)