### PR TITLE
feat: 日別アーカイブモーダルをSPで縦レイアウトに対応する（Issue #129）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -300,6 +300,7 @@ html, body {
   .monthly-day-empty {
     display: none;
   }
+
 }
 
 .monthly-nav {
@@ -548,4 +549,22 @@ html, body {
   height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
+}
+
+@media (max-width: 576px) {
+  .daily-modal {
+    min-width: unset;
+    width: 95vw;
+    max-height: 85vh;
+    overflow-y: auto;
+  }
+
+  .daily-modal-body {
+    flex-direction: column;
+  }
+
+  .daily-modal-left {
+    flex: none;
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## 概要
- SPでモーダルが左側にはみ出ていた問題を修正
- SPメディアクエリをPCスタイルより後に移動し、CSSカスケードを正しく適用
- `overflow-y: auto` を追加してモーダル内のスクロールに対応

## 動作確認
- [ ] SPサイズ（576px以下）でモーダルが画面内に収まって表示されること
- [ ] モーダルが縦レイアウト（チャート→ログ）で表示されること
- [ ] コンテンツが多い場合にモーダル内でスクロールできること
- [ ] PCサイズでレイアウトが崩れていないこと

Closes #129