### PR TITLE
feat: 日別アーカイブモーダルの履歴一覧をSP向けに2行構成へ最適化する（Issue #130）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -534,14 +534,29 @@ html, body {
 
   li {
     font-size: 0.8rem;
-    display: flex;
-    gap: 8px;
+  }
+}
+
+.daily-modal-log-item {
+  display: flex;
+  flex-direction: column;
+  padding: 8px 0;
+  border-bottom: 1px solid #f0f0f0;
+
+  &:last-child {
+    border-bottom: none;
   }
 }
 
 .daily-modal-log-time {
   color: #888;
+  font-size: 0.75rem;
   flex-shrink: 0;
+}
+
+.daily-modal-log-name {
+  font-size: 0.875rem;
+  word-break: break-all;
 }
 
 .monthly-day-dot {

--- a/app/javascript/react/monthly/DailyArchiveModal.jsx
+++ b/app/javascript/react/monthly/DailyArchiveModal.jsx
@@ -97,9 +97,9 @@ export default function DailyArchiveModal({ date, onClose }) {
                             <p className="daily-modal-section-title">今日の行動履歴</p>
                             <ul className="daily-modal-logs">
                                 {data.logs.map((log, i) => (
-                                    <li key={i}>
+                                    <li key={i} className="daily-modal-log-item">
                                         <span className="daily-modal-log-time">{formatTime(log.logged_at)}</span>
-                                        {log.activity_name}
+                                        <span className="daily-modal-log-name">{log.activity_name}</span>
                                     </li>
                                 ))}
                             </ul>


### PR DESCRIPTION
## 概要
- 履歴の各行を「時刻（上）＋アクティビティ名（下）」の2行構成に変更
- 各アイテムに縦paddingと区切り線を追加してタップ領域・視認性を確保
- 長いアクティビティ名でも折り返し対応（`word-break: break-all`）

## 動作確認
- [ ] SPで時刻が上・アクティビティ名が下の2行構成で表示されること
- [ ] 各ログアイテムに区切り線があり読みやすいこと
- [ ] 長い名前が折り返されてレイアウトが崩れないこと
- [ ] PCでも表示が崩れていないこと

Closes #130