### PR TITLE
feat: ユーザー設定画面の土台を作る（Issue #100）

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,0 +1,6 @@
+class SettingsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+  end
+end

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,0 +1,1 @@
+<div id="settings-app"></div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,7 +11,7 @@
         <%= link_to "今日の記録", learning_path, class: "nav-link #{'active' if current_page?(learning_path)}" %>
         <%= link_to "週次記録", weekly_path, class: "nav-link #{'active' if current_page?(weekly_path)}" %>
         <%= link_to "カレンダー", monthly_path, class: "nav-link" %>
-        <%= link_to "ユーザー設定", "#", class: "nav-link" %>
+        <%= link_to "ユーザー設定", settings_path, class: "nav-link #{'active' if current_page?(settings_path)}" %>
       </nav>
 
       <div class="header-right">
@@ -37,7 +37,7 @@
       <%= link_to "今日の記録", learning_path, class: "mobile-link #{'active' if current_page?(learning_path)}" %>
       <%= link_to "週次記録", weekly_path, class: "mobile-link" %>
       <%= link_to "カレンダー", monthly_path, class: "mobile-link" %>
-      <%= link_to "ユーザー設定", "#", class: "mobile-link" %>
+      <%= link_to "ユーザー設定", settings_path, class: "mobile-link #{'active' if current_page?(settings_path)}" %>
       <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "mobile-logout" %>
     <% else %>
       <%= link_to "ログイン", new_user_session_path, class: "mobile-link" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
 
   get 'weekly', to: 'weekly#index', as: :weekly
   get 'monthly', to: 'monthly#index', as: :monthly
+  get 'settings', to: 'settings#index', as: :settings
 
   get 'analytics_path', to: 'records#analytics', as: 'analytics_records'
   resources :records


### PR DESCRIPTION
## 概要
- `GET /settings` ルーティング追加
- `SettingsController#index` 作成（`authenticate_user!` によりログインユーザーのみアクセス可）
- ビューに `<div id="settings-app"></div>` を配置
- ヘッダー（PC・SP）に `settings_path` へのリンクを追加

## 動作確認
- [ ] `/settings` にアクセスして空のページが表示されること
- [ ] 未ログイン状態でアクセスするとログイン画面にリダイレクトされること
- [ ] ヘッダーの「ユーザー設定」リンクから遷移できること
- [ ] SPのハンバーガーメニューからも遷移できること

Closes #100