### PR TITLE
feat: activitiesにuser_idとactiveを追加するマイグレーション（Issue #263）

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,3 +1,4 @@
 class Activity < ApplicationRecord
+  belongs_to :user, optional: true
   has_many :records, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   
   has_many :records, dependent: :destroy
+  has_many :activities, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 20 }
   

--- a/db/migrate/20260328140331_add_user_id_and_active_to_activities.rb
+++ b/db/migrate/20260328140331_add_user_id_and_active_to_activities.rb
@@ -1,0 +1,7 @@
+class AddUserIdAndActiveToActivities < ActiveRecord::Migration[7.1]
+  def change
+    add_column :activities, :user_id, :integer
+    add_column :activities, :active, :boolean, default: true, null: false
+    add_index :activities, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_02_25_090806) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_28_140331) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -21,7 +21,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_02_25_090806) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "public_id", default: -> { "gen_random_uuid()" }, null: false
+    t.integer "user_id"
+    t.boolean "active", default: true, null: false
     t.index ["public_id"], name: "index_activities_on_public_id", unique: true
+    t.index ["user_id"], name: "index_activities_on_user_id"
   end
 
   create_table "records", force: :cascade do |t|


### PR DESCRIPTION
## 概要
- `activities` テーブルに `user_id`（integer）を追加
- `activities` テーブルに `active`（boolean, default: true, null: false）を追加
- `user_id` にインデックスを追加
- `User` モデルに `has_many :activities, dependent: :destroy` を追加
- `Activity` モデルに `belongs_to :user, optional: true` を追加（既存データがnullのため）

## 動作確認
- [ ] マイグレーション後にschema.rbにuser_idとactiveが存在すること
- [ ] 既存のactivitiesデータが正常に動作すること
- [ ] 新規activityにuser_idを付与して保存できること

Closes #263