### PR TITLE
feat: 行動カテゴリ一覧の表示・ON/OFF切り替えを実装する（Issue #102）

### DIFF
--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -2,6 +2,9 @@ class Api::SettingsController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    render json: { name: current_user.name, email: current_user.email}
+    categories = current_user.activities.map do |a|
+      { id: a.id, name: a.name, icon: a.icon, active: a.active }
+    end
+    render json: { name: current_user.name, email: current_user.email, categories: categories}
   end
 end

--- a/app/javascript/react/settings/CategoryList.jsx
+++ b/app/javascript/react/settings/CategoryList.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+export default function CategoryList({ categories, onToggle }) {
+    if (categories.length === 0) {
+        return <p>カテゴリがありません</p>
+    }
+
+    return (
+        <ul className="category-list">
+            {categories.map((cat) => (
+                <li key={cat.id} className="category-list-item">
+                    <span className="category-icon">{cat.icon}</span>
+                    <span className="category-name">{cat.name}</span>
+                    <button className="category-delete-btn">削除</button>
+                    <button
+                        className={`category-toggle ${cat.active ? "on" : "off"}`}
+                        onClick={() => onToggle(cat.id)}
+                    >
+                        {cat.active ? "ON" : "OFF"}
+                    </button>
+                </li>
+            ))}
+        </ul>
+    );
+}

--- a/app/javascript/react/settings/SettingsApp.jsx
+++ b/app/javascript/react/settings/SettingsApp.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from "react";
+import CategoryList from "./CategoryList";
 
 export default function SettingsApp() {
     const [data, setData] = useState(null);
+    const [categories, setCategories] = useState([]);
     const [error, setError] = useState(null);
 
     useEffect(() => {
@@ -10,18 +12,31 @@ export default function SettingsApp() {
                 if (!res.ok) throw new Error("取得失敗");
                 return res.json();
             })
-            .then((json) => setData(json))
-            .catch((err
-            ) => setError(err.message));
+            .then((json) => {
+                setData(json);
+                setCategories(json.categories);
+            })
+            .catch((err) => setError(err.message));
     }, []);
+
+    const handleToggle = (id) => {
+        setCategories((prev) =>
+            prev.map((cat) => 
+                cat.id === id ? { ...cat, active: !cat.active} : cat
+            )
+        );
+    };
 
     if (error) return <p>{error}</p>;
     if (!data) return <p>読み込み中…</p>;
 
     return (
-        <div>
-            <h1>ユーザー設定(仮)</h1>
-            <pre>{JSON.stringify(data, null, 2)}</pre>
+        <div className="setting-wrap">
+            <h1 className="setting-title">ユーザー設定(仮)</h1>
+            <section className="settings-section">
+                <h2 className="settings-section-title">行動カテゴリ</h2>
+                <CategoryList categories={categories} onToggle={handleToggle} />
+            </section>
         </div>
     )
 }


### PR DESCRIPTION
## 概要
- `/api/settings` がカテゴリ一覧（id・name・icon・active）を返すよう修正
- `CategoryList` コンポーネントを作成（アイコン・名前・削除ボタン・ON/OFFスイッチ）
- `SettingsApp` でカテゴリのstateを管理し、ON/OFFトグルで`active`を反転
- サーバーへの保存は未実装（state管理のみ）

## 動作確認
- [ ] `/settings` でカテゴリ一覧が表示されること
- [ ] ON/OFFボタンを押すと表示が切り替わること
- [ ] カテゴリがない場合「カテゴリがありません」と表示されること

Closes #102