### PR TITLE
feat: カテゴリ追加ボタンとモーダルの表示を実装する（Issue #103）

### DIFF
--- a/app/javascript/react/settings/CategoryFormModal.jsx
+++ b/app/javascript/react/settings/CategoryFormModal.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export default function CategoryFormModal({ onClose }) {
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <button className="modal-close" onClick={onClose}>×</button>
+                <h2 className="modal-title">カテゴリを追加</h2>
+                <p>（フォームは次のイシューで実装）</p>
+            </div>
+        </div>
+    );
+}

--- a/app/javascript/react/settings/SettingsApp.jsx
+++ b/app/javascript/react/settings/SettingsApp.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from "react";
 import CategoryList from "./CategoryList";
+import CategoryFormModal from "./CategoryFormModal";
 
 export default function SettingsApp() {
     const [data, setData] = useState(null);
     const [categories, setCategories] = useState([]);
     const [error, setError] = useState(null);
+    const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false);
 
     useEffect(() => {
         fetch("/api/settings")
@@ -36,7 +38,16 @@ export default function SettingsApp() {
             <section className="settings-section">
                 <h2 className="settings-section-title">行動カテゴリ</h2>
                 <CategoryList categories={categories} onToggle={handleToggle} />
+                <button
+                    className="category-add-btn"
+                    onClick={() => setIsCategoryModalOpen(true)}
+                >
+                    + カテゴリ追加
+                </button>
             </section>
+            {isCategoryModalOpen && (
+                <CategoryFormModal onClose={() => setIsCategoryModalOpen(false)} />
+            )}
         </div>
-    )
+    );
 }


### PR DESCRIPTION
## 概要
- `CategoryFormModal` コンポーネントを作成（枠のみ、フォームは次Issue）
- `SettingsApp` に `isCategoryModalOpen` stateを追加
- 「＋ カテゴリ追加」ボタン押下でモーダルが開く
- ×ボタン・背景クリックでモーダルが閉じる

## 動作確認
- [ ] 「＋ カテゴリ追加」ボタンを押すとモーダルが開くこと
- [ ] ×ボタンで閉じること
- [ ] 背景クリックで閉じること

Closes #103