### PR TITLE
feat: 行動カテゴリ追加モーダルの入力フォームと登録処理を実装する（Issue #104）

### DIFF
--- a/app/controllers/api/activities_controller.rb
+++ b/app/controllers/api/activities_controller.rb
@@ -12,4 +12,19 @@ class Api::ActivitiesController < ApplicationController
       }
     }
   end
+
+  def create
+    activity = current_user.activities.build(activity_params)
+    if activity.save
+      render json: { id: activity.id, name: activity.name, icon: activity.icon, active: activity.active }, status: :created
+    else
+      render json: { errors: activity.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def activity_params
+    params.require(:activity).permit(:name, :icon)
+  end
 end

--- a/app/javascript/react/settings/CategoryFormModal.jsx
+++ b/app/javascript/react/settings/CategoryFormModal.jsx
@@ -1,12 +1,67 @@
-import React from "react";
+import React, { useState } from "react";
 
-export default function CategoryFormModal({ onClose }) {
+const COLORS = ["#818cf8", "#fb923c", "#34d399", "#f43f5e", "#900ce9"];
+
+export default function CategoryFormModal({ onClose, onAdd }) {
+    const [name, setName] = useState("");
+    const [icon, setIcon] = useState("");
+    const [error, setError] = useState(null);
+
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        if (!name.trim()) {
+            setError("カテゴリ名を入力してください");
+            return;
+        }
+        const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+        fetch("/api/activities", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRF-Token": csrfToken,
+            },
+            body: JSON.stringify({ activity: { name, icon } }),
+        })
+            .then((res) => res.json().then((data) => ({ ok: res.ok, data})))
+            .then(({ ok, data }) => {
+                if (!ok) {
+                    setError(data.errors?.join(", ") || "登録失敗");
+                    return;
+                }
+                onAdd(data);
+                onClose();
+            })
+            .catch(() => setError("通信エラーが発生しました"));
+    };
+
     return (
         <div className="modal-overlay" onClick={onClose}>
             <div className="modal-content" onClick={(e) => e.stopPropagation()}>
                 <button className="modal-close" onClick={onClose}>×</button>
                 <h2 className="modal-title">カテゴリを追加</h2>
-                <p>（フォームは次のイシューで実装）</p>
+                {error && <p className="modal-error">{error}</p>}
+                <form onSubmit={handleSubmit}>
+                    <div className="modal-field">
+                        <label>アイコン(絵文字)</label>
+                        <input
+                            type="text"
+                            value={icon}
+                            onChange={(e) => setIcon(e.target.value)}
+                            placeholder="例：📚"
+                            maxLength={2}
+                        />
+                    </div>
+                    <div className="modal-field">
+                        <label>カテゴリ名</label>
+                        <input
+                            type="text"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            placeholder="例：勉強"
+                        />
+                    </div>
+                    <button type="submit" className="modal-submit-btn">追加する</button>
+                </form>
             </div>
         </div>
     );

--- a/app/javascript/react/settings/SettingsApp.jsx
+++ b/app/javascript/react/settings/SettingsApp.jsx
@@ -29,6 +29,10 @@ export default function SettingsApp() {
         );
     };
 
+    const handleAdd = (newCategory) => {
+        setCategories((prev) => [...prev, newCategory]);
+    };
+
     if (error) return <p>{error}</p>;
     if (!data) return <p>読み込み中…</p>;
 
@@ -46,7 +50,7 @@ export default function SettingsApp() {
                 </button>
             </section>
             {isCategoryModalOpen && (
-                <CategoryFormModal onClose={() => setIsCategoryModalOpen(false)} />
+                <CategoryFormModal onClose={() => setIsCategoryModalOpen(false)} onAdd={handleAdd} />
             )}
         </div>
     );

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
   namespace :api do
     get "dashboard/today", to: "dashboard#today"
     get "activities", to: "activities#index"
+    post "activities", to: "activities#create"
     post "dashboard/logs", to: "dashboard_logs#create"
     post "dashboard/stop", to: "dashboard_stop#create"
     get "weekly", to: "weekly#index"


### PR DESCRIPTION
## 概要
- `CategoryFormModal` にアイコン・カテゴリ名の入力フォームを追加
- 名前の必須バリデーション実装
- `POST /api/activities` エンドポイント追加（CSRFトークン対応）
- 登録成功時にモーダルを閉じてカテゴリ一覧に即時反映
- 失敗時にエラーメッセージ表示

## 動作確認
- [ ] カテゴリ名・アイコンを入力して「追加する」を押すと一覧に追加されること
- [ ] カテゴリ名が空の場合にバリデーションエラーが表示されること
- [ ] 追加後にモーダルが閉じること

Closes #104