### PR TITLE
feat: ON/OFFをDBに保存してダッシュボードに反映する（Issue #270）

### DIFF
--- a/app/controllers/api/activities_controller.rb
+++ b/app/controllers/api/activities_controller.rb
@@ -2,7 +2,7 @@ class Api::ActivitiesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    activities = Activity.order(:id)
+    activities = current_user.activities.where(active: true).order(:id)
 
     render json: activities.map { |a| 
       {
@@ -19,6 +19,15 @@ class Api::ActivitiesController < ApplicationController
       render json: { id: activity.id, name: activity.name, icon: activity.icon, active: activity.active }, status: :created
     else
       render json: { errors: activity.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    activity = current_user.activities.find(params[:id])
+    if activity.update(active: params[:active])
+      render json: { id: activity.id, active: activity.active }
+    else
+      render json: { errors: activity.errors.full_messages}, status: :unprocessable_entity
     end
   end
 

--- a/app/javascript/react/settings/SettingsApp.jsx
+++ b/app/javascript/react/settings/SettingsApp.jsx
@@ -22,11 +22,24 @@ export default function SettingsApp() {
     }, []);
 
     const handleToggle = (id) => {
-        setCategories((prev) =>
-            prev.map((cat) => 
-                cat.id === id ? { ...cat, active: !cat.active} : cat
-            )
-        );
+        const cat = categories.find((c) => c.id === id);
+        const newActive = !cat.active;
+
+        fetch(`/api/activities/${id}`, {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]')?.content,
+            },
+            body: JSON.stringify({ active: newActive }),
+        })
+            .then((res) => {
+                if (!res.ok) throw new Error("更新失敗");
+                setCategories((prev) =>
+                    prev.map((c) => c.id === id ? { ...c, active: newActive } : c)
+                );
+            })
+            .catch(() => alert("更新に失敗しました"));
     };
 
     const handleAdd = (newCategory) => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
     get "dashboard/today", to: "dashboard#today"
     get "activities", to: "activities#index"
     post "activities", to: "activities#create"
+    patch "activities/:id", to: "activities#update"
     post "dashboard/logs", to: "dashboard_logs#create"
     post "dashboard/stop", to: "dashboard_stop#create"
     get "weekly", to: "weekly#index"


### PR DESCRIPTION
## 概要
- `PATCH /api/activities/:id` エンドポイントを追加（activeフラグ更新）
- ON/OFFトグル時にAPIを叩いてDBに保存するよう`handleToggle`を修正
- `/api/activities` が`current_user`の`active: true`のカテゴリのみ返すよう修正
- ページリロード後もON/OFF状態が保持される

## 動作確認
- [ ] ON/OFFを切り替えてページをリロードしても状態が保たれること
- [ ] OFFにしたカテゴリがダッシュボードの選択肢から消えること
- [ ] ONに戻すとダッシュボードに再表示されること

Closes #270