### PR TITLE
feat: カテゴリ削除機能を実装する（Issue #264）

### DIFF
--- a/app/controllers/api/activities_controller.rb
+++ b/app/controllers/api/activities_controller.rb
@@ -31,6 +31,12 @@ class Api::ActivitiesController < ApplicationController
     end
   end
 
+  def destroy
+    activity = current_user.activities.find(params[:id])
+    activity.destroy
+    render json: { message: "削除しました" }
+  end
+
   private
 
   def activity_params

--- a/app/javascript/react/settings/CategoryList.jsx
+++ b/app/javascript/react/settings/CategoryList.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-export default function CategoryList({ categories, onToggle }) {
+export default function CategoryList({ categories, onToggle, onDelete }) {
     if (categories.length === 0) {
         return <p>カテゴリがありません</p>
     }
@@ -11,7 +11,12 @@ export default function CategoryList({ categories, onToggle }) {
                 <li key={cat.id} className="category-list-item">
                     <span className="category-icon">{cat.icon}</span>
                     <span className="category-name">{cat.name}</span>
-                    <button className="category-delete-btn">削除</button>
+                    <button 
+                        className="category-delete-btn"
+                        onClick={() => onDelete(cat.id)}
+                    >
+                        削除
+                    </button>
                     <button
                         className={`category-toggle ${cat.active ? "on" : "off"}`}
                         onClick={() => onToggle(cat.id)}

--- a/app/javascript/react/settings/SettingsApp.jsx
+++ b/app/javascript/react/settings/SettingsApp.jsx
@@ -46,6 +46,21 @@ export default function SettingsApp() {
         setCategories((prev) => [...prev, newCategory]);
     };
 
+    const handleDelete = (id) => {
+        if(!confirm("削除しますか？")) return;
+        fetch(`/api/activities/${id}`, {
+            method: "DELETE",
+            headers: {
+                "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]')?.content,
+            },
+        })
+            .then((res) => {
+                if(!res.ok) throw new Error("削除失敗");
+                setCategories((prev) => prev.filter((c) => c.id !== id));
+            })
+            .catch(() => alert("削除に失敗しました"));
+    }
+
     if (error) return <p>{error}</p>;
     if (!data) return <p>読み込み中…</p>;
 
@@ -54,7 +69,7 @@ export default function SettingsApp() {
             <h1 className="setting-title">ユーザー設定(仮)</h1>
             <section className="settings-section">
                 <h2 className="settings-section-title">行動カテゴリ</h2>
-                <CategoryList categories={categories} onToggle={handleToggle} />
+                <CategoryList categories={categories} onToggle={handleToggle} onDelete={handleDelete} />
                 <button
                     className="category-add-btn"
                     onClick={() => setIsCategoryModalOpen(true)}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
     get "activities", to: "activities#index"
     post "activities", to: "activities#create"
     patch "activities/:id", to: "activities#update"
+    delete "activities/:id", to: "activities#destroy"
     post "dashboard/logs", to: "dashboard_logs#create"
     post "dashboard/stop", to: "dashboard_stop#create"
     get "weekly", to: "weekly#index"


### PR DESCRIPTION
## 概要
- `DELETE /api/activities/:id` エンドポイントを追加
- 削除ボタン押下時に確認ダイアログを表示
- 確認後にAPIを叩いてDBから削除・一覧から即時除去
- 自分のカテゴリのみ削除可能（`current_user.activities.find`で認可）

## 動作確認
- [ ] 削除ボタンを押すと確認ダイアログが出ること
- [ ] OKを押すとカテゴリが一覧から消えること
- [ ] キャンセルを押すと何も起きないこと
- [ ] 削除後にページをリロードしても消えていること

Closes #264