### PR TITLE
feat: 目標設定（カテゴリ＋割合）のフォームと保存処理を実装する（Issue #105）

### DIFF
--- a/app/controllers/api/settings_controller.rb
+++ b/app/controllers/api/settings_controller.rb
@@ -5,6 +5,21 @@ class Api::SettingsController < ApplicationController
     categories = current_user.activities.map do |a|
       { id: a.id, name: a.name, icon: a.icon, active: a.active }
     end
-    render json: { name: current_user.name, email: current_user.email, categories: categories}
+    render json: {
+       name: current_user.name,
+       email: current_user.email, 
+       categories: categories,
+       goal_activity_id: current_user.goal_activity_id,
+       goal_percentage: current_user.goal_percentage 
+      }
   end
+
+  def update
+    if current_user.update(goal_activity_id: params[:goal_activity_id], goal_percentage: params[:goal_percentage])
+      render json: { goal_activity_id: current_user.goal_activity_id, goal_percentage: current_user.goal_percentage }
+    else
+      render json: { errors: current_user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
 end

--- a/app/javascript/react/settings/SettingsApp.jsx
+++ b/app/javascript/react/settings/SettingsApp.jsx
@@ -7,6 +7,8 @@ export default function SettingsApp() {
     const [categories, setCategories] = useState([]);
     const [error, setError] = useState(null);
     const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false);
+    const [goalActivityId, setGoalActivityId] = useState("");
+    const [goalPercentage, setGoalPercentage] = useState(50);
 
     useEffect(() => {
         fetch("/api/settings")
@@ -17,6 +19,8 @@ export default function SettingsApp() {
             .then((json) => {
                 setData(json);
                 setCategories(json.categories);
+                setGoalActivityId(json.goal_activity_id || "");
+                setGoalPercentage(json.goal_percentage ?? 50);
             })
             .catch((err) => setError(err.message));
     }, []);
@@ -44,6 +48,22 @@ export default function SettingsApp() {
 
     const handleAdd = (newCategory) => {
         setCategories((prev) => [...prev, newCategory]);
+    };
+
+    const handleGoalSave = () => {
+        fetch("/api/settings", {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]')?.content,
+            },
+            body: JSON.stringify({ goal_activity_id: goalActivityId || null, goal_percentage: goalPercentage }),
+        })
+            .then((res) => {
+                if (!res.ok) throw new Error("保存失敗");
+                alert("保存しました");
+            })
+            .catch(() => alert("保存に失敗しました"));
     };
 
     const handleDelete = (id) => {
@@ -76,6 +96,34 @@ export default function SettingsApp() {
                 >
                     + カテゴリ追加
                 </button>
+            </section>
+            <section className="settings-section">
+                <h2 className="settings-section-title">目標設定</h2>
+                <div className="modal-field">
+                    <label>目標カテゴリ</label>
+                    <select
+                        value={goalActivityId}
+                        onChange={(e) => setGoalActivityId(e.target.value)}
+                    >
+                        <option value="">未設定</option>
+                        {categories.map((cat) => (
+                            <option key={cat.id} value={cat.id}>
+                                {cat.icon} {cat.name}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div className="modal-field">
+                    <label>目標割合</label>
+                    <input
+                        type="number"
+                        min={0}
+                        max={100}
+                        value={goalPercentage}
+                        onChange={(e) => setGoalPercentage(Number(e.target.value))}
+                    /> %
+                </div>
+                <button className="goal-save-btn" onClick={handleGoalSave}>保存する</button>
             </section>
             {isCategoryModalOpen && (
                 <CategoryFormModal onClose={() => setIsCategoryModalOpen(false)} onAdd={handleAdd} />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,5 +37,6 @@ Rails.application.routes.draw do
     get "monthly", to: "monthly#index"
     get "days/:date", to: "days#show"
     get "settings", to: "settings#show"
+    patch "settings", to: "settings#update"
   end
 end

--- a/db/migrate/20260402060459_add_goal_to_users.rb
+++ b/db/migrate/20260402060459_add_goal_to_users.rb
@@ -1,0 +1,6 @@
+class AddGoalToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :goal_activity_id, :integer
+    add_column :users, :goal_percentage, :integer, default: 50
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_03_28_140331) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_02_060459) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -51,6 +51,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_03_28_140331) do
     t.datetime "updated_at", null: false
     t.string "name"
     t.integer "streak"
+    t.integer "goal_activity_id"
+    t.integer "goal_percentage", default: 50
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要
- `users` テーブルに `goal_activity_id`・`goal_percentage`（default: 50）を追加するマイグレーション
- `/api/settings` のレスポンスに目標設定値を追加
- `PATCH /api/settings` で目標設定をDBに保存するエンドポイント追加
- 設定画面に目標カテゴリ（プルダウン）・目標割合（数値入力）・保存ボタンを追加

## 動作確認
- [ ] 目標カテゴリ・割合を変更して「保存する」を押すと保存されること
- [ ] リロード後も設定値が保持されること
- [ ] 目標カテゴリは自分のカテゴリ一覧から選択できること

Closes #105