### PR TITLE
feat: 開発環境でリセットメールを確認できるようにする（Issue #149）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :development do
   # gem "spring"
 
   gem 'rubocop'
+  gem "letter_opener_web"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,8 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cgi (0.5.0)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     crass (1.0.6)
@@ -143,6 +145,17 @@ GEM
       railties (>= 6.0.0)
     json (2.16.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -336,6 +349,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   jsbundling-rails (~> 1.3)
+  letter_opener_web
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.6)

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,9 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= @resource.email %> 様</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワードリセットのリクエストを受け付けました。<br>
+以下のリンクからパスワードを変更してください。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワードを変更する', edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p>このリクエストに心当たりがない場合は、このメールを無視してください。<br>
+リンクにアクセスしない限り、パスワードは変更されません。</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,6 +41,10 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :letter_opener_web
+
+  config.action_mailer.perform_deliveries = true
+
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
+
   devise_for :users, controllers: {
     sessions: 'users/sessions',
     registrations: 'users/registrations'


### PR DESCRIPTION
## 概要
- `letter_opener_web` gem を追加
- `development.rb` に `delivery_method: :letter_opener_web` を設定
- `/letter_opener` ルートを開発環境のみ追加
- パスワードリセットメールを日本語化

## 動作確認
- [ ] パスワードリセット申請後に `/letter_opener` でメールが確認できる
- [ ] メール内のリンクにリセットトークンが含まれている
- [ ] メール文章が日本語で表示される

Closes #149