### PR TITLE
feat: トークン有効期限の設定確認とトースト表示時間を延長する（Issue #151）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1054,7 +1054,7 @@ html, body {
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
   z-index: 9999;
   white-space: nowrap;
-  animation: toastIn 0.3s ease forwards, toastOut 0.4s ease 3.5s forwards;
+  animation: toastIn 0.3s ease forwards, toastOut 0.4s ease 6s forwards;
 
   &.app-toast-notice { background: #f0fdf4; color: #15803d; }
   &.app-toast-error  { background: #fef2f2; color: #b91c1c; }


### PR DESCRIPTION
## 概要
- `reset_password_within = 6.hours` が設定済みであることを確認
- 期限切れ時に `devise-i18n` によって日本語エラーが表示されることを確認
- エラートーストの表示時間を 3.5s → 6s に延長

## 動作確認
- 有効期限内：パスワード再設定できる
- 有効期限外：「トークンの有効期限が切れました」エラーが日本語で表示される

Closes #151