### PR TITLE
fix: メールのリセットURLのhost設定を修正する

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,7 +96,7 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  config.action_mailer.default_url_options = { host: 'https://study-keeper.onrender.com', port: 'https'  }
+  config.action_mailer.default_url_options = { host: 'study-keeper.onrender.com', protocol: 'https' }
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true


### PR DESCRIPTION
## 原因
`default_url_options` の設定が `{ host: 'https://study-keeper.onrender.com', port: 'https' }` になっており、
生成されるURLが `https://study-keeper.onrender.com:https/users/password/edit?...` という不正な形式になっていた。

## 修正
`host` から `https://` を除去し、`port: 'https'` を `protocol: 'https'` に変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)