### PR TITLE
feat: 利用規約ページを作成する（Issue #162）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1081,3 +1081,56 @@ html, body {
     }
   }
 }
+
+// 利用規約ページ
+.terms-wrap {
+  padding: 48px 24px;
+}
+
+.terms-inner {
+  max-width: 720px;
+  margin: 0 auto;
+  background: #fff;
+  border-radius: 16px;
+  padding: 48px 40px;
+  box-shadow: 0 4px 20px rgba(129, 140, 248, 0.1);
+
+  @media (max-width: 576px) {
+    padding: 24px 16px;
+  }
+}
+
+.terms-title {
+  font-size: 1.6rem;
+  font-weight: bold;
+  color: #1e1b4b;
+  margin-bottom: 32px;
+  padding-bottom: 16px;
+  border-bottom: 2px solid #e5e7eb;
+}
+
+.terms-section {
+  margin-bottom: 32px;
+
+  h2 {
+    font-size: 1rem;
+    font-weight: bold;
+    color: #1e1b4b;
+    margin-bottom: 8px;
+  }
+
+  p, ul {
+    font-size: 0.9rem;
+    color: #555;
+    line-height: 1.8;
+    margin: 0;
+  }
+
+  ul {
+    padding-left: 1.5rem;
+
+    li {
+      margin-bottom: 4px;
+    }
+  }
+}

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -2,4 +2,7 @@ class StaticPagesController < ApplicationController
   def top;
     redirect_to learning_path if user_signed_in?
   end
+
+  def terms;
+  end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="footer-inner">
     <span class="footer-copy">© 2025 Study-keeper</span>
     <div class="footer-links">
-      <a href="#">利用規約</a>
+      <%= link_to "利用規約", terms_path %>
       <a href="#">プライバシーポリシー</a>
     </div>
   </div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,31 @@
+<div class="terms-wrap">
+  <div class ="terms-inner">
+    <h1 class="terms-title">利用規約</h1>
+
+    <section class="terms-section">
+      <h2>第1条（適用）</h2>
+      <p>本規約は、Study-keeper（以下「本サービス」）の利用に関する条件を定めるものです。ユーザーは本規約に同意した上で本サービスを利用するものとします。</p>
+    </section>
+
+    <section class="terms-section">
+      <h2>第2条（禁止事項）</h2>
+      <p>ユーザーは以下の行為を行ってはなりません。</p>
+      <ul>
+        <li>法令または公序良俗に違反する行為</li>
+        <li>他のユーザーまたは第三者への迷惑行為</li>
+        <li>本サービスの運営を妨害する行為</li>
+      </ul>
+    </section>
+
+    <section class="terms-section">
+      <h2>第3条（免責事項）</h2>
+      <p>本サービスの利用により生じた損害について、運営者は一切の責任を負いません。</p>
+    </section>
+
+    <section class="terms-section">
+      <h2>第4条（規約の変更）</h2>
+      <p>運営者は必要に応じて本規約を変更することができます。変更後の規約はサービス上に掲示した時点で効力を持ちます。</p>
+    </section>
+  </div>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
   root 'static_pages#top'
+  get 'terms', to: 'static_pages#terms', as: :terms
 
   get  'learning_path', to: 'study_records#new', as: :learning
   post 'learning_path', to: 'study_records#create'


### PR DESCRIPTION
## 概要
- `GET /terms` ルーティングを追加
- `StaticPagesController#terms` アクションを追加
- `terms.html.erb` を作成（4条構成のダミー文面）
- フッターの利用規約リンクを `terms_path` に変更

Closes #162