### PR TITLE
feat: プライバシーポリシーページを作成する（Issue #163）

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -5,4 +5,7 @@ class StaticPagesController < ApplicationController
 
   def terms;
   end
+
+  def privacy;
+  end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
     <span class="footer-copy">© 2025 Study-keeper</span>
     <div class="footer-links">
       <%= link_to "利用規約", terms_path %>
-      <a href="#">プライバシーポリシー</a>
+      <%= link_to "プライバシーポリシー", privacy_path %>
     </div>
   </div>
 </footer>

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,0 +1,29 @@
+<div class="terms-wrap">
+  <div class="terms-inner">
+    <h1 class="terms-title">プライバシーポリシー</h1>
+
+    <section class="terms-section">
+      <h2>第1条（個人情報の取得）</h2>
+      <p>本サービスは、ユーザー登録時にメールアドレスを取得します。</p>
+    </section>
+
+    <section class="terms-section">
+      <h2>第2条（個人情報の利用目的）</h2>
+      <p>取得した個人情報は、以下の目的で利用します。</p>
+      <ul>
+        <li>本サービスの提供・運営</li>
+        <li>ユーザーへの連絡（パスワードリセットメールなど）</li>
+      </ul>
+    </section>
+
+    <section class="terms-section">
+      <h2>第3条（第三者への提供）</h2>
+      <p>法令に基づく場合を除き、個人情報を第三者に提供することはありません。</p>
+    </section>
+
+    <section class="terms-section">
+      <h2>第4条（お問い合わせ）</h2>
+      <p>個人情報の取り扱いに関するお問い合わせは、サービス内のお問い合わせフォームよりご連絡ください。</p>
+    </section>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   # root "posts#index"
   root 'static_pages#top'
   get 'terms', to: 'static_pages#terms', as: :terms
+  get 'privacy', to: 'static_pages#privacy', as: :privacy
 
   get  'learning_path', to: 'study_records#new', as: :learning
   post 'learning_path', to: 'study_records#create'


### PR DESCRIPTION
## 概要
- `GET /privacy` ルーティングを追加
- `StaticPagesController#privacy` アクションを追加
- `privacy.html.erb` を作成（4条構成のダミー文面）
- フッターのプライバシーポリシーリンクを `privacy_path` に変更

Closes #163