### PR TITLE
feat: 日別OGP用の共有URLとshare_linksテーブルを追加する（Issue #172, #173）

### DIFF
--- a/app/controllers/share_controller.rb
+++ b/app/controllers/share_controller.rb
@@ -1,0 +1,8 @@
+class ShareController < ApplicationController
+  skip_before_action :authenticate_user!, raise: false
+
+  def daily
+    @share_link = ShareLink.find_by(token: params[:token], share_type: :daily)
+    render file: 'public/404.html', status: :not_found unless @share_link
+  end
+end

--- a/app/models/share_link.rb
+++ b/app/models/share_link.rb
@@ -1,0 +1,13 @@
+class ShareLink < ApplicationRecord
+  belongs_to :user
+
+  enum share_type: { daily: 'daily' }
+
+  before_create :generate_token
+
+  private
+
+  def generate_token
+    self.token = SecureRandom.urlsafe_base64(16)
+  end
+end

--- a/app/views/share/daily.html.erb
+++ b/app/views/share/daily.html.erb
@@ -1,0 +1,6 @@
+<div class="terms-wrap">
+  <div class="terms-inner">
+    <h1 class="terms-title">日別記録</h1>
+    <p><%= @share_link.target_date %> の記録</p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Rails.application.routes.draw do
   get 'analytics_path', to: 'records#analytics', as: 'analytics_records'
   resources :records
 
+  get 'share/daily/:token', to: 'share#daily', as: :share_daily
+
   namespace :api do
     get "dashboard/today", to: "dashboard#today"
     get "activities", to: "activities#index"

--- a/db/migrate/20260414121606_create_share_links.rb
+++ b/db/migrate/20260414121606_create_share_links.rb
@@ -1,0 +1,12 @@
+class CreateShareLinks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :share_links do |t|
+      t.string :token, null: false
+      t.references :user, null: false, foreign_key: true
+      t.string :share_type, null: false
+      t.date :target_date, null: false
+      t.timestamps
+    end
+    add_index :share_links, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_02_141810) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_14_121606) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -41,6 +41,17 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_02_141810) do
     t.index ["user_id"], name: "index_records_on_user_id"
   end
 
+  create_table "share_links", force: :cascade do |t|
+    t.string "token", null: false
+    t.bigint "user_id", null: false
+    t.string "share_type", null: false
+    t.date "target_date", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["token"], name: "index_share_links_on_token", unique: true
+    t.index ["user_id"], name: "index_share_links_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -68,4 +79,5 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_02_141810) do
 
   add_foreign_key "records", "activities"
   add_foreign_key "records", "users"
+  add_foreign_key "share_links", "users"
 end


### PR DESCRIPTION
## 概要
- `share_links` テーブルを追加（token / user_id / share_type / target_date）
- `ShareLink` モデルを作成（`before_create` でUUIDsafe トークン自動生成）
- `GET /share/daily/:token` ルーティングを追加
- `ShareController#daily` を作成（未ログインでもアクセス可、token不正は404）
- 仮の日別共有ページビューを作成

## 動作確認
- コンソールで `ShareLink.create!` → トークン発行確認
- `/share/daily/:token` で仮ページ表示確認
- 未ログイン状態でもアクセス可能なことを確認

Closes #172
Closes #173