### PR TITLE
feat: 日別共有ページの表示内容を実装する（Issue #174）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1082,6 +1082,124 @@ html, body {
   }
 }
 
+// 日別共有ページ
+.share-wrap {
+  padding: 48px 24px;
+}
+
+.share-card {
+  max-width: 560px;
+  margin: 0 auto;
+  background: #fff;
+  border-radius: 20px;
+  padding: 40px 36px;
+  box-shadow: 0 4px 20px rgba(129, 140, 248, 0.12);
+
+  @media (max-width: 576px) {
+    padding: 24px 16px;
+  }
+}
+
+.share-header {
+  margin-bottom: 28px;
+  padding-bottom: 20px;
+  border-bottom: 2px solid #e5e7eb;
+}
+
+.share-label {
+  font-size: 0.75rem;
+  font-weight: bold;
+  color: #818cf8;
+  letter-spacing: 0.08em;
+  margin-bottom: 8px;
+}
+
+.share-title {
+  font-size: 1.4rem;
+  font-weight: bold;
+  color: #1e1b4b;
+  margin: 0;
+}
+
+.share-empty {
+  color: #888;
+  font-size: 0.9rem;
+}
+
+.share-total {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.share-total-label {
+  font-size: 0.8rem;
+  color: #888;
+}
+
+.share-total-value {
+  font-size: 1.6rem;
+  font-weight: bold;
+  color: #1e1b4b;
+}
+
+.share-categories {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.share-category-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.share-category-info {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100px;
+  flex-shrink: 0;
+}
+
+.share-category-icon {
+  font-size: 1.1rem;
+}
+
+.share-category-name {
+  font-size: 0.85rem;
+  color: #333;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.share-category-bar-wrap {
+  flex: 1;
+  height: 8px;
+  background: #f0f0f0;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.share-category-bar {
+  height: 100%;
+  background: #818cf8;
+  border-radius: 4px;
+  transition: width 0.4s ease;
+}
+
+.share-category-time {
+  font-size: 0.8rem;
+  color: #666;
+  width: 80px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
 // 利用規約ページ
 .terms-wrap {
   padding: 48px 24px;

--- a/app/controllers/share_controller.rb
+++ b/app/controllers/share_controller.rb
@@ -3,6 +3,16 @@ class ShareController < ApplicationController
 
   def daily
     @share_link = ShareLink.find_by(token: params[:token], share_type: :daily)
-    render file: 'public/404.html', status: :not_found unless @share_link
+    return render file: 'public/404.html', status: :not_found unless @share_link
+  
+    date = @share_link.target_date
+    logs = @share_link.user.records
+                      .where(logged_at: date.beginning_of_day..date.end_of_day)
+                      .includes(:activity)
+    
+    @date = date
+    @summary = WeeklySummaryService.new(logs).call
+    @total_minutes = @summary.sum { |s| s[:total_minutes] }
+    @top_category = @summary.first
   end
 end

--- a/app/views/share/daily.html.erb
+++ b/app/views/share/daily.html.erb
@@ -1,6 +1,32 @@
-<div class="terms-wrap">
-  <div class="terms-inner">
-    <h1 class="terms-title">日別記録</h1>
-    <p><%= @share_link.target_date %> の記録</p>
+<div class="share-wrap">
+  <div class="share-card">
+    <div class="share-header">
+      <p class="share-label">Study-keeper</p>
+      <h1 class="share-title"><%= @date.strftime('%Y年%-m月%-d日') %> の記録</h1>
+    </div>
+
+    <% if @summary.empty? %>
+      <p class="share-empty">この日の記録はありません。</p>
+    <% else %>
+      <div class="share-total">
+        <span class="share-total-label">合計時間</span>
+        <span class="share-total-value"><%= @total_minutes / 60 %>時間 <%= @total_minutes % 60 %>分</span>
+      </div>
+
+      <div class="share-categories">
+        <% @summary.each do |s| %>
+          <div class="share-category-item">
+            <div class="share-category-info">
+              <span class="share-category-icon"><%= s[:icon] %></span>
+              <span class="share-category-name"><%= s[:activity_name] %></span>
+            </div>
+            <div class="share-category-bar-wrap">
+              <div class="share-category-bar" style="width: <%= s[:percentage] %>%"></div>
+            </div>
+            <span class="share-category-time"><%= s[:total_minutes] %>分（<%= s[:percentage] %>%）</span>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
- `ShareController#daily` に `WeeklySummaryService` を使った集計ロジックを追加
- 日付・合計時間・カテゴリ別時間・バーグラフを表示
- 記録なしの日は「この日の記録はありません」を表示

## 動作確認
- コンソールで `ShareLink.create!` → トークン発行
- `/share/daily/:token` でデータ表示確認
- 記録なしの日も正常表示確認

Closes #174