### PR TITLE
feat: 日別共有ページにOGPメタタグを追加する（Issue #175）

### DIFF
--- a/app/controllers/share_controller.rb
+++ b/app/controllers/share_controller.rb
@@ -14,5 +14,9 @@ class ShareController < ApplicationController
     @summary = WeeklySummaryService.new(logs).call
     @total_minutes = @summary.sum { |s| s[:total_minutes] }
     @top_category = @summary.first
+
+    @og_title = "#{@date.strftime('%Y年%-m月%-d日')}の記録 - Study-keeper"
+    desc_parts = @summary.first(3).map { |s| "#{s[:activity_name]} #{s[:total_minutes]}分" }
+    @og_desc = @summary.empty? ? "この日の記録はありません" : "合計#{@total_minutes / 60}時間#{@total_minutes % 60}分 / #{desc_parts.join(' / ')}"
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <%= yield :og_tags %>
   </head>
 
   <body>

--- a/app/views/share/daily.html.erb
+++ b/app/views/share/daily.html.erb
@@ -1,3 +1,13 @@
+<% content_for :og_tags do %>
+  <meta property="og:title" content="<%= @og_title %>" />
+  <meta property="og:description" content="<%= @og_desc %>" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="<%= request.original_url %>" />
+  <meta property="og:image" content="<%= root_url %>ogp.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+<% end %>
+
+
 <div class="share-wrap">
   <div class="share-card">
     <div class="share-header">


### PR DESCRIPTION
## 概要
- `application.html.erb` の `<head>` に `yield :og_tags` を追加
- `ShareController#daily` に `@og_title` / `@og_desc` の生成ロジックを追加
- `daily.html.erb` に `content_for :og_tags` でOGPメタタグを出力
- `og:image` は暫定で `root_url + 'ogp.png'`（#176 で差し替え予定）

Closes #175