### PR TITLE
feat: 日別シェアボタンのURLをshare/daily/:tokenに切り替える（Issue #177）

### DIFF
--- a/app/controllers/api/days_controller.rb
+++ b/app/controllers/api/days_controller.rb
@@ -9,11 +9,18 @@ class Api::DaysController < ApplicationController
 
     summary = WeeklySummaryService.new(logs).call
 
+    share_link = ShareLink.find_or_create_by(
+      user: current_user,
+      share_type: :daily,
+      target_date: date
+    )
+
     render json: {
       date: date.iso8601,
       total_minutes: summary.sum { |s| s[:total_minutes] },
       per_category: summary.map { |s| { name: s[:activity_name], minutes: s[:total_minutes], ratio: s[:percentage] } },
-      logs: logs.map { |log| { activity_name: log.activity.name, logged_at: log.logged_at, ended_at: log.ended_at } }
+      logs: logs.map { |log| { activity_name: log.activity.name, logged_at: log.logged_at, ended_at: log.ended_at } },
+      share_token: share_link.token
     }
   rescue ArgumentError
     render json: { error: "不正な日付です" }, status: :bad_request

--- a/app/javascript/react/monthly/DailyArchiveModal.jsx
+++ b/app/javascript/react/monthly/DailyArchiveModal.jsx
@@ -84,7 +84,7 @@ export default function DailyArchiveModal({ date, onClose }) {
                                 className="weekly-share-btn mt-2"
                                 onClick={() => {
                                     const text = buildDailyShareText(date, data);
-                                    const shareUrl = `${window.location.origin}/monthly?date=${date}`;
+                                    const shareUrl = `${window.location.origin}/share/daily/${data.share_token}`;
                                     const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(shareUrl)}`;
                                     window.open(url, "_blank");
                                 }}


### PR DESCRIPTION
## 概要
- `Api::DaysController#show` で `ShareLink.find_or_create_by` を呼び出し、トークンをJSONレスポンスに追加
- `DailyArchiveModal` のシェアURLを `/monthly?date=...` から `/share/daily/:token` 形式に変更
- シェアリンクを踏んだユーザーがログイン不要の公開ページに遷移できるようになった

Closes #177