### PR TITLE
feat: 日別シェアテキストにアクティビティアイコンと絵文字を追加する

### DIFF
--- a/app/controllers/api/days_controller.rb
+++ b/app/controllers/api/days_controller.rb
@@ -18,7 +18,7 @@ class Api::DaysController < ApplicationController
     render json: {
       date: date.iso8601,
       total_minutes: summary.sum { |s| s[:total_minutes] },
-      per_category: summary.map { |s| { name: s[:activity_name], minutes: s[:total_minutes], ratio: s[:percentage] } },
+      per_category: summary.map { |s| { name: s[:activity_name], minutes: s[:total_minutes], ratio: s[:percentage], icon: s[:icon] } },
       logs: logs.map { |log| { activity_name: log.activity.name, logged_at: log.logged_at, ended_at: log.ended_at } },
       share_token: share_link.token
     }

--- a/app/javascript/react/monthly/DailyArchiveModal.jsx
+++ b/app/javascript/react/monthly/DailyArchiveModal.jsx
@@ -28,14 +28,14 @@ function formatTime(isoString) {
 }
 
 function buildDailyShareText(date, data) {
-    if(!data || data.total_minutes === 0) return `${date}の記録はありませんでした\nStudyKeeper\n`;
+    if(!data || data.total_minutes === 0) return `${date}の記録はありませんでした\n#StudyKeeper\n`;
     const total = formatMinutes(data.total_minutes);
     const top = data.per_category
         .filter((c) => c.minutes > 0)
         .slice(0, 3)
-        .map((c) => `${c.name} : ${formatMinutes(c.minutes)}`)
+        .map((c) => `${c.icon} ${c.name} : ${formatMinutes(c.minutes)}`)
         .join("\n");
-    return `${formatDateHeader(date)}の活動記録\n合計：${total}\n${top}\n#StudyKeeper\n`;
+    return `⭐ ${formatDateHeader(date)}の活動記録\n⏱ 合計：${total}\n${top}\n#StudyKeeper\n`;
 }
 
 export default function DailyArchiveModal({ date, onClose }) {


### PR DESCRIPTION
## 概要
- `per_category` レスポンスに `icon` フィールドを追加
- シェアテキストの日付に ⭐、合計に ⏱、各活動にアクティビティのアイコン絵文字を表示