### PR TITLE
週次シェアページURLと週次シェアリンクのサポートを追加

### DIFF
--- a/app/controllers/share_controller.rb
+++ b/app/controllers/share_controller.rb
@@ -19,4 +19,26 @@ class ShareController < ApplicationController
     desc_parts = @summary.first(3).map { |s| "#{s[:activity_name]} #{s[:total_minutes]}分" }
     @og_desc = @summary.empty? ? "この日の記録はありません" : "合計#{@total_minutes / 60}時間#{@total_minutes % 60}分 / #{desc_parts.join(' / ')}"
   end
+
+  def weekly
+    @share_link = ShareLink.find_by(token: params[:token], share_type: :weekly)
+    return render file: 'public/404.html', status: :not_found unless @share_link
+  
+    date = @share_link.target_date
+    @week_start = date.beginning_of_week(:monday)
+    @week_end = date.end_of_week(:monday)
+    logs = @share_link.user.records
+                      .where(logged_at: @week_start.beginning_of_day..@week_end.end_of_day)
+                      .includes(:activity)
+    
+    @summary = WeeklySummaryService.new(logs).call
+    @total_minutes = @summary.sum { |s| s[:total_minutes] }
+    @top_category = @summary.first
+
+    week_range = "#{@week_start.strftime('%-m/%-d')} - #{@week_end.strftime('%-m/%-d')}"
+    @og_title = "#{week_range}の記録 - Study-keeper"
+    desc_parts = @summary.first(3).map { |s| "#{s[:activity_name]} #{s[:total_minutes]}分" }
+    @og_desc = @summary.empty? ? "この週の記録はありません" : "合計#{@total_minutes / 60}時間#{@total_minutes % 60}分 / #{desc_parts.join(' / ')}"
+  end
+
 end

--- a/app/models/share_link.rb
+++ b/app/models/share_link.rb
@@ -1,7 +1,7 @@
 class ShareLink < ApplicationRecord
   belongs_to :user
 
-  enum share_type: { daily: 'daily' }
+  enum share_type: { daily: 'daily', weekly: 'weekly' }
 
   before_create :generate_token
 

--- a/app/views/share/weekly.html.erb
+++ b/app/views/share/weekly.html.erb
@@ -1,0 +1,42 @@
+<% content_for :og_tags do %>
+  <meta property="og:title" content="<%= @og_title %>" />
+  <meta property="og:description" content="<%= @og_desc %>" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="<%= request.original_url %>" />
+  <meta property="og:image" content="<%= root_url %>ogp.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+<% end %>
+
+
+<div class="share-wrap">
+  <div class="share-card">
+    <div class="share-header">
+      <p class="share-label">Study-keeper</p>
+      <h1 class="share-title"><%= @week_start.strftime('%Y年%-m月%-d日') %> 〜 <%= @week_end.strftime('%-m月%-d日') %> の記録</h1>
+    </div>
+
+    <% if @summary.empty? %>
+      <p class="share-empty">この週の記録はありません。</p>
+    <% else %>
+      <div class="share-total">
+        <span class="share-total-label">合計時間</span>
+        <span class="share-total-value"><%= @total_minutes / 60 %>時間 <%= @total_minutes % 60 %>分</span>
+      </div>
+
+      <div class="share-categories">
+        <% @summary.each do |s| %>
+          <div class="share-category-item">
+            <div class="share-category-info">
+              <span class="share-category-icon"><%= s[:icon] %></span>
+              <span class="share-category-name"><%= s[:activity_name] %></span>
+            </div>
+            <div class="share-category-bar-wrap">
+              <div class="share-category-bar" style="width: <%= s[:percentage] %>%"></div>
+            </div>
+            <span class="share-category-time"><%= s[:total_minutes] %>分（<%= s[:percentage] %>%）</span>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
   resources :records
 
   get 'share/daily/:token', to: 'share#daily', as: :share_daily
+  get 'share/weekly/:token', to: 'share#weekly', as: :share_weekly
 
   namespace :api do
     get "dashboard/today", to: "dashboard#today"


### PR DESCRIPTION
"このPRでは、/share/weekly/:token を登録し、ShareLinkにweeklyタイプを追加し、週次シェアページのビューとコントローラーロジックを実装します。"