### PR TITLE
週別OGP：share_links に weekly を対応させる（token発行の土台）

### DIFF
--- a/app/controllers/api/weekly_controller.rb
+++ b/app/controllers/api/weekly_controller.rb
@@ -15,6 +15,12 @@ class Api::WeeklyController < ApplicationController
 
     goal_activity = weekly_goal ? Activity.find_by(id: weekly_goal.activity_id) : nil
 
+    share_link = ShareLink.find_or_create_by(
+      user: current_user,
+      share_type: :weekly,
+      target_date: week_start
+    )
+
     render json: {
       week_start:           week_start.iso8601,
       week_end:             week_end.iso8601,
@@ -24,7 +30,8 @@ class Api::WeeklyController < ApplicationController
       goal_activity_id:     weekly_goal&.activity_id,
       goal_activity_name:   goal_activity&.name,
       goal_activity_icon:   goal_activity&.icon,
-      goal_percentage:      weekly_goal&.percentage || 50
+      goal_percentage:      weekly_goal&.percentage || 50,
+      share_token:          share_link.token
     }
   end
 end


### PR DESCRIPTION
## 概要
共有URLが推測されないように、週別共有用の token を発行できるようにする。

## 実装内容
- [x] `share_links.share_type` に `weekly` を追加（enum等）
- [x] `target_week_start`（date）を保持できるようにする（以下どちらか採用）
  - [x] A: 既存 `target_date` を「週開始日」として流用する
  - [ ] B: `target_week_start` カラムを追加（分かりやすさ優先）
- [x] tokenから `user_id + week_start` を引けるようにする
- [x] 同じ user_id + week_start のリンクは再利用する（任意：二重発行防止）

## 完了条件
- [x] token から「誰の・どの週」が特定できる

Closes #180