### PR TITLE
feat: 週別共有ページの表示内容を最小で実装する（#181）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1200,6 +1200,87 @@ html, body {
   flex-shrink: 0;
 }
 
+.share-goal {
+  margin-top: 20px;
+  padding: 14px 16px;
+  background: #f5f3ff;
+  border-radius: 12px;
+  border-left: 3px solid #818cf8;
+}
+
+.share-goal-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.share-goal-label {
+  font-size: 0.75rem;
+  font-weight: bold;
+  color: #6366f1;
+}
+
+.share-goal-badge {
+  font-size: 0.7rem;
+  font-weight: bold;
+  padding: 2px 8px;
+  border-radius: 999px;
+
+  &.achieved {
+    background: #dcfce7;
+    color: #16a34a;
+  }
+
+  &.unachieved {
+    background: #fef9c3;
+    color: #a16207;
+  }
+}
+
+.share-goal-body {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.share-goal-activity {
+  font-size: 0.9rem;
+  font-weight: bold;
+  color: #1e1b4b;
+}
+
+.share-goal-numbers {
+  font-size: 0.8rem;
+  color: #666;
+}
+
+.share-streak {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  padding: 12px 16px;
+  background: #fff7ed;
+  border-radius: 12px;
+  border-left: 3px solid #f97316;
+}
+
+.share-streak-icon {
+  font-size: 1.1rem;
+}
+
+.share-streak-value {
+  font-size: 1rem;
+  font-weight: bold;
+  color: #c2410c;
+}
+
+.share-streak-label {
+  font-size: 0.75rem;
+  color: #9a3412;
+}
+
 // 利用規約ページ
 .terms-wrap {
   padding: 48px 24px;

--- a/app/controllers/share_controller.rb
+++ b/app/controllers/share_controller.rb
@@ -33,11 +33,24 @@ class ShareController < ApplicationController
     
     @summary = WeeklySummaryService.new(logs).call
     @total_minutes = @summary.sum { |s| s[:total_minutes] }
-    @top_category = @summary.first
+    @top_categories = @summary.first(3)
+
+    user = @share_link.user
+    @streak = user.streak
+
+    weekly_goal = WeeklyGoal.find_by(user: user, week_start: @week_start)
+    if weekly_goal
+      goal_activity = @summary.find { |s| s[:db_id] == weekly_goal.activity_id }
+      @goal = {
+        activity_name: goal_activity&.fetch(:activity_name),
+        target_percentage: weekly_goal.percentage,
+        actual_percentage: goal_activity ? goal_activity[:percentage] : 0
+      }
+    end
 
     week_range = "#{@week_start.strftime('%-m/%-d')} - #{@week_end.strftime('%-m/%-d')}"
     @og_title = "#{week_range}の記録 - Study-keeper"
-    desc_parts = @summary.first(3).map { |s| "#{s[:activity_name]} #{s[:total_minutes]}分" }
+    desc_parts = @top_categories.map { |s| "#{s[:activity_name]} #{s[:total_minutes]}分" }
     @og_desc = @summary.empty? ? "この週の記録はありません" : "合計#{@total_minutes / 60}時間#{@total_minutes % 60}分 / #{desc_parts.join(' / ')}"
   end
 

--- a/app/views/share/weekly.html.erb
+++ b/app/views/share/weekly.html.erb
@@ -24,7 +24,7 @@
       </div>
 
       <div class="share-categories">
-        <% @summary.each do |s| %>
+        <% @top_categories.each do |s| %>
           <div class="share-category-item">
             <div class="share-category-info">
               <span class="share-category-icon"><%= s[:icon] %></span>
@@ -37,6 +37,30 @@
           </div>
         <% end %>
       </div>
+
+      <% if @goal %>
+        <% achieved = @goal[:actual_percentage] >= @goal[:target_percentage] %>
+        <div class="share-goal">
+          <div class="share-goal-header">
+            <span class="share-goal-label">週次目標</span>
+            <span class="share-goal-badge <%= achieved ? 'achieved' : 'unachieved' %>">
+              <%= achieved ? '達成' : '未達' %>
+            </span>
+          </div>
+          <div class="share-goal-body">
+            <span class="share-goal-activity"><%= @goal[:activity_name] %></span>
+            <span class="share-goal-numbers">目標 <%= @goal[:target_percentage] %>% → 実績 <%= @goal[:actual_percentage] %>%</span>
+          </div>
+        </div>
+      <% end %>
+
+      <% if @streak > 0 %>
+        <div class="share-streak">
+          <span class="share-streak-icon">🔥</span>
+          <span class="share-streak-value"><%= @streak %>日連続</span>
+          <span class="share-streak-label">継続中</span>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- 週別共有ページ（`/share/weekly/:token`）の表示内容を実装
- 上位カテゴリを最大3件に絞って表示
- ストリーク・週次目標の達成状況（達成/未達バッジ）を追加

## Changes
- `ShareController#weekly`: `@top_categories`（上位3件）、`@streak`、`@goal` を追加
- `share/weekly.html.erb`: カテゴリ上位3件表示、目標達成バッジ、ストリーク表示を追加
- `application.scss`: `.share-goal`、`.share-streak` のスタイルを追加

## Test plan
- [ ] 記録ありの週で合計時間・上位3カテゴリ・割合が表示される
- [ ] 週次目標がある場合に達成/未達バッジが表示される
- [ ] ストリークが1以上の場合に表示される
- [ ] 記録なしの週で「この週の記録はありません」が表示される

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)