### PR TITLE
feat: 週別共有ページにOGPメタタグを出す（#182）

### DIFF
--- a/app/controllers/share_controller.rb
+++ b/app/controllers/share_controller.rb
@@ -50,7 +50,7 @@ class ShareController < ApplicationController
 
     week_range = "#{@week_start.strftime('%-m/%-d')} - #{@week_end.strftime('%-m/%-d')}"
     @og_title = "#{week_range}の記録 - Study-keeper"
-    desc_parts = @top_categories.map { |s| "#{s[:activity_name]} #{s[:total_minutes]}分" }
+    desc_parts = @top_categories.map { |s| "#{s[:activity_name]} #{s[:total_minutes] / 60}時間#{s[:total_minutes] % 60}分(#{s[:percentage]}%)" }
     @og_desc = @summary.empty? ? "この週の記録はありません" : "合計#{@total_minutes / 60}時間#{@total_minutes % 60}分 / #{desc_parts.join(' / ')}"
   end
 


### PR DESCRIPTION
## Summary
- 週別共有ページ（`/share/weekly/:token`）のOGPメタタグは PR #310 時点で実装済み
- 今回は `og:description` のフォーマットを「分」→「時間/分(%)」形式に調整

## Changes
- `ShareController#weekly`: descriptionのカテゴリ表示を `Ruby 5時間30分(69%)` 形式に変更

## Test plan
- [ ] DevToolsで `og:description` に合計時間・上位3カテゴリ(時間/分/%)が含まれる
- [ ] 記録なしの場合「この週の記録はありません」になる

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)