### PR TITLE
feat: 週別共有ボタンのURLをshare/weekly/:tokenに切り替える（#183）

### DIFF
--- a/app/javascript/react/weekly/WeeklyApp.jsx
+++ b/app/javascript/react/weekly/WeeklyApp.jsx
@@ -117,7 +117,7 @@ export default function WeeklyApp() {
 
                     <button className="weekly-share-btn" onClick={() => {
                         const text = buildWeeklyShareText(data);
-                        const shareUrl = `${window.location.origin}/weekly?week=${data.week_start}`;
+                        const shareUrl = `${window.location.origin}/share/weekly/${data.share_token}`;
                         const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(shareUrl)}`;
                         window.open(url, "_blank");
                     }}>𝕏 シェアする</button>


### PR DESCRIPTION
## Summary
- 週次記録画面の「シェアする」ボタンのURLを `/weekly?week=...` から `/share/weekly/:token` に変更
- APIレスポンスの `share_token` を使用（既存の `find_or_create_by` ロジックを活用）

## Changes
- `WeeklyApp.jsx`: `shareUrl` を `share/weekly/:token` 形式に変更（1行）

## Test plan
- [ ] シェアボタン押下でTwitter投稿画面に `/share/weekly/:token` のURLが入る
- [ ] 前週/次週に移動してシェアしても、その週のtokenになる

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)