### PR TITLE
feat: 日別共有ページ用の動的OGP画像を生成する（#315）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN apt-get update -qq && apt-get install -y \
   nodejs \
   npm \
   postgresql-client \
+  imagemagick \
+  libmagickwand-dev \
+  fonts-noto-cjk \
 && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,6 +11,9 @@ RUN apt-get update -qq && apt-get install -y \
   git \
   curl \
   vim \
+  imagemagick \
+  libmagickwand-dev \
+  fonts-noto-cjk \
 && rm -rf /var/lib/apt/lists/*
 
 # 作業ディレクトリ

--- a/app/controllers/ogp_controller.rb
+++ b/app/controllers/ogp_controller.rb
@@ -1,0 +1,28 @@
+class OgpController < ApplicationController
+  skip_before_action :authenticate_user!, raise: false
+
+  def daily
+    share_link = ShareLink.find_by(token: params[:token], share_type: :daily)
+    return render file: "public/404.html", status: :not_found unless share_link
+
+    date = share_link.target_date
+    logs = share_link.user.records
+                     .where(logged_at: date.beginning_of_day..date.end_of_day)
+                     .includes(:activity)
+
+    summary = WeeklySummaryService.new(logs).call
+    total_minutes = summary.sum { |s| s[:total_minutes] }
+
+    tmpfile = DailyOgpImageService.new(
+      date: date,
+      summary: summary,
+      total_minutes: total_minutes
+    ).call
+
+    data = File.binread(tmpfile.path)
+    send_data data, type: "image/png", disposition: "inline"
+  ensure
+    tmpfile&.close
+    tmpfile&.unlink
+  end
+end

--- a/app/services/daily_ogp_image_service.rb
+++ b/app/services/daily_ogp_image_service.rb
@@ -1,0 +1,74 @@
+class DailyOgpImageService
+  FONT = "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"
+  WIDTH = 1200
+  HEIGHT = 630
+  BG_COLOR = "#1e1b4b"
+  ACCENT_COLOR = "#818cf8"
+  BAR_COLOR = "#818cf8"
+  BAR_BG_COLOR = "#2d2a5e"
+  BAR_MAX_WIDTH = 700
+
+  def initialize(date:, summary:, total_minutes:)
+    @date = date
+    @summary = summary
+    @total_minutes = total_minutes
+  end
+
+  def call
+    tmpfile = Tempfile.new(["daily_ogp", ".png"])
+    args = base_args + content_args + [tmpfile.path]
+
+    success = system("convert", *args)
+    raise "OGP image generation failed" unless success
+
+    tmpfile
+  end
+
+  private
+
+  def base_args
+    [
+      "-size", "#{WIDTH}x#{HEIGHT}",
+      "xc:#{BG_COLOR}",
+      "-font", FONT,
+    ]
+  end
+
+  def content_args
+    args = []
+
+    # Study-keeper ラベル
+    args += ["-pointsize", "28", "-fill", ACCENT_COLOR, "-draw", "text 60,70 'Study-keeper'"]
+
+    # 日付
+    args += ["-fill", "white", "-pointsize", "52", "-draw", "text 60,155 '#{@date.strftime('%Y年%-m月%-d日')}の記録'"]
+
+    # 区切り線
+    args += ["-fill", ACCENT_COLOR, "-draw", "rectangle 60,175 #{WIDTH - 60},178"]
+
+    if @total_minutes == 0
+      args += ["-fill", "#aaaacc", "-pointsize", "40", "-draw", "text 60,280 'この日の記録はありません'"]
+    else
+      h = @total_minutes / 60
+      m = @total_minutes % 60
+      total_text = h > 0 ? "#{h}時間#{m}分" : "#{m}分"
+
+      args += ["-fill", "#aaaacc", "-pointsize", "30", "-draw", "text 60,240 '合計時間'"]
+      args += ["-fill", "white", "-pointsize", "72", "-draw", "text 60,320 '#{total_text}'"]
+
+      @summary.first(3).each_with_index do |s, i|
+        y_base = 400 + i * 70
+        bar_width = (s[:percentage].to_f / 100 * BAR_MAX_WIDTH).round.clamp(4, BAR_MAX_WIDTH)
+        name = s[:activity_name].to_s.slice(0, 10)
+        time_text = "#{s[:total_minutes] / 60}時間#{s[:total_minutes] % 60}分 (#{s[:percentage]}%)"
+
+        args += ["-fill", BAR_BG_COLOR, "-draw", "rectangle 60,#{y_base} #{60 + BAR_MAX_WIDTH},#{y_base + 28}"]
+        args += ["-fill", BAR_COLOR,    "-draw", "rectangle 60,#{y_base} #{60 + bar_width},#{y_base + 28}"]
+        args += ["-fill", "white",      "-pointsize", "26", "-draw", "text 60,#{y_base - 8} '#{name}'"]
+        args += ["-fill", "#aaaacc",    "-pointsize", "24", "-draw", "text #{60 + BAR_MAX_WIDTH + 16},#{y_base + 22} '#{time_text}'"]
+      end
+    end
+
+    args
+  end
+end

--- a/app/views/share/daily.html.erb
+++ b/app/views/share/daily.html.erb
@@ -3,7 +3,7 @@
   <meta property="og:description" content="<%= @og_desc %>" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= request.original_url %>" />
-  <meta property="og:image" content="<%= root_url %>ogp.png" />
+  <meta property="og:image" content="<%= ogp_daily_url(@share_link.token) %>" />
   <meta name="twitter:card" content="summary_large_image" />
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
   get 'share/daily/:token', to: 'share#daily', as: :share_daily
   get 'share/weekly/:token', to: 'share#weekly', as: :share_weekly
 
+  get 'ogp/daily/:token', to: 'ogp#daily', as: :ogp_daily
+
   namespace :api do
     get "dashboard/today", to: "dashboard#today"
     get "activities", to: "activities#index"


### PR DESCRIPTION
## Summary
- `DailyOgpImageService` をImageMagick（`system("convert")`）で実装
- 画像サイズ：1200x630（OGP標準）、日本語フォント：Noto Sans CJK JP
- 画像内容：日付・合計時間・上位3カテゴリのバーグラフ
- `/ogp/daily/:token` エンドポイントを追加（`OgpController#daily`）
- `share/daily.html.erb` の `og:image` を動的URLに変更
- Dockerfile/Dockerfile.devにImageMagick・`fonts-noto-cjk` を追加

## Test plan
- [ ] `http://localhost:3000/ogp/daily/:token` で画像が表示される
- [ ] 記録なしでも画像生成が落ちない
- [ ] `share/daily/:token` の `og:image` が動的URLになっている

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)