### PR TITLE
fix: OGP画像の日本語フォントをプロジェクトに同梱

### DIFF
--- a/app/services/daily_ogp_image_service.rb
+++ b/app/services/daily_ogp_image_service.rb
@@ -1,5 +1,5 @@
 class DailyOgpImageService
-  FONT = "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"
+  FONT = Rails.root.join("vendor/fonts/NotoSansCJK-Regular.ttc").to_s
   WIDTH = 1200
   HEIGHT = 630
   BG_COLOR = "#1e1b4b"


### PR DESCRIPTION
## Summary
- 本番環境でOGP画像の日本語が表示されない問題を修正
- システムフォントへの依存をなくし `vendor/fonts/NotoSansCJK-Regular.ttc` を同梱
- `DailyOgpImageService` のフォントパスをプロジェクト内パスに変更

## Test plan
- [ ] `/ogp/daily/:token` の画像に日本語が表示される
- [ ] 本番デプロイ後も日本語が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)