### PR TITLE
feat: usersテーブルにprovider/uidを追加（#186）

### DIFF
--- a/db/migrate/20260422094334_add_omniauth_to_users.rb
+++ b/db/migrate/20260422094334_add_omniauth_to_users.rb
@@ -1,0 +1,7 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+    add_index :users, [:provider, :uid], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_14_121606) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_22_094334) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -63,7 +63,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_14_121606) do
     t.string "name"
     t.integer "streak", default: 0, null: false
     t.jsonb "settings"
+    t.string "provider"
+    t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
## 概要
- `provider`（string）・`uid`（string）カラムを users テーブルに追加
- `index_users_on_provider_and_uid`（unique）インデックスを追加

## 動作確認
- [ ] マイグレーションが正常に実行される
- [ ] schema.rb に provider / uid / ユニークインデックスが含まれる

Closes #186