### PR TITLE
feat: GoogleOAuthコールバックを実装（#187）

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,30 +1,18 @@
-# frozen_string_literal: true
-
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  # You should configure your model like this:
-  # devise :omniauthable, omniauth_providers: [:twitter]
+  def google_oauth2
+    auth = request.env["omniauth.auth"]
+    @user = User.from_omniauth(auth)
 
-  # You should also create an action method in this controller like this:
-  # def twitter
-  # end
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication
+      set_flash_message(:notice, :success, kind: "Google") if is_navigational_format?
+    else
+      session["devise.google_data"] = auth.except(:extra)
+      redirect_to new_user_registration_url, alert: @user.errors.full_messages.join(", ")
+    end
+  end
 
-  # More info at:
-  # https://github.com/heartcombo/devise#omniauth
-
-  # GET|POST /resource/auth/twitter
-  # def passthru
-  #   super
-  # end
-
-  # GET|POST /users/auth/twitter/callback
-  # def failure
-  #   super
-  # end
-
-  # protected
-
-  # The path used when OmniAuth fails
-  # def after_omniauth_failure_path_for(scope)
-  #   super(scope)
-  # end
+  def failure
+    redirect_to root_path, alert: "Googleログインに失敗しました。"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,5 +11,12 @@ class User < ApplicationRecord
 
   store_accessor :settings, :default_page
   validates :name, presence: true, length: { maximum: 20 }
-  
+
+  def self.from_omniauth(auth)
+    find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|
+      user.email    = auth.info.email
+      user.name     = auth.info.name.to_s.slice(0, 20)
+      user.password = Devise.friendly_token[0, 20]
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,8 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: {
     sessions: 'users/sessions',
-    registrations: 'users/registrations'
+    registrations: 'users/registrations',
+    omniauth_callbacks: 'users/omniauth_callbacks'
   }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
## 概要
- `devise_for` に `omniauth_callbacks` コントローラーを追加
- `Users::OmniauthCallbacksController#google_oauth2` を実装
- `User.from_omniauth` で provider+uid による検索/新規作成ロジックを追加

## 変更
- `config/routes.rb`: omniauth_callbacks ルーティング追加
- `app/controllers/users/omniauth_callbacks_controller.rb`: google_oauth2 / failure アクション実装
- `app/models/user.rb`: `from_omniauth` クラスメソッドを追加

## 動作確認
- [ ] サーバーが正常起動する
- [ ] Google Client ID/Secret を設定すればGoogleログインが通る

Closes #187