### PR TITLE
feat: Googleログインボタンの部分テンプレを作成（#189）

### DIFF
--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -40,3 +40,38 @@
     }
   }
 }
+
+.oauth-buttons {
+  margin-top: 1.2rem;
+}
+
+.oauth-divider {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 1rem;
+  color: #aaa;
+  font-size: 0.85rem;
+
+  &::before, &::after {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: #e5e7eb;
+  }
+}
+
+.oauth-google-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.95rem;
+  padding: 0.6rem 1rem;
+  border-color: #ddd;
+  color: #333;
+
+  &:hover {
+    background: #f9f9f9;
+    border-color: #bbb;
+  }
+}

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -69,5 +69,6 @@
       </div>
 
     <% end %>
+    <%= render "shared/oauth_buttons" %>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -22,5 +22,6 @@
         <%= link_to "パスワードをお忘れですか？", new_user_password_path, class: "forgot-password-link" %>
       </div>
     <% end %>
+    <%= render "shared/oauth_buttons" %>
   </div>
 </div>

--- a/app/views/shared/_oauth_buttons.html.erb
+++ b/app/views/shared/_oauth_buttons.html.erb
@@ -1,0 +1,18 @@
+<div class="oauth-buttons">
+  <div class="oauth-divider">
+    <span>または</span>
+  </div>
+  <%= link_to user_google_oauth2_omniauth_authorize_path,
+        method: :post,
+        class: "btn btn-outline-dark w-100 oauth-google-btn",
+        data: { turbo: false } do %>
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 48 48" class="me-2">
+      <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
+      <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
+      <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
+      <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.18 1.48-4.97 2.31-8.16 2.31-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+      <path fill="none" d="M0 0h48v48H0z"/>
+    </svg>
+    Googleで続行
+  <% end %>
+</div>


### PR DESCRIPTION
## 概要
- `app/views/shared/_oauth_buttons.html.erb` を作成
- ログイン画面・登録画面に `render "shared/oauth_buttons"` で共通利用
- Googleロゴ（SVG）付きのボタンを配置
- 将来GitHub/X等を追加しやすい構造

## 動作確認
- [ ] ログイン画面にGoogleで続行ボタンが表示される
- [ ] 登録画面にGoogleで続行ボタンが表示される
- [ ] クリックするとGoogle認証へ遷移する（Client ID設定後）

Closes #189