### PR TITLE
feat: Googleソーシャルログインを実装する（#191）

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,10 +13,21 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 20 }
 
   def self.from_omniauth(auth)
-    find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|
-      user.email    = auth.info.email
-      user.name     = auth.info.name.to_s.slice(0, 20)
-      user.password = Devise.friendly_token[0, 20]
+    user = find_by(provider: auth.provider, uid: auth.uid)
+    return user if user
+
+    user = find_by(email: auth.info.email)
+    if user
+      user.update(provider: auth.provider, uid: auth.uid)
+      return user
     end
+
+    create(
+      provider: auth.provider,
+      uid: auth.uid,
+      email: auth.info.email,
+      name: auth.info.name.to_s.slice(0, 20),
+      password: Devise.friendly_token[0, 20]
+    )
   end
 end

--- a/app/views/shared/_oauth_buttons.html.erb
+++ b/app/views/shared/_oauth_buttons.html.erb
@@ -2,7 +2,7 @@
   <div class="oauth-divider">
     <span>または</span>
   </div>
-  <%= link_to user_google_oauth2_omniauth_authorize_path,
+  <%= button_to user_google_oauth2_omniauth_authorize_path,
         method: :post,
         class: "btn btn-outline-dark w-100 oauth-google-btn",
         data: { turbo: false } do %>


### PR DESCRIPTION
## 概要
- `link_to`から`button_to`に変更してOAuth認証リクエストをPOSTで正しく送信
- `from_omniauth`を改善し、既存のメール/パスワードアカウントにGoogleを紐付け可能に
- Google Cloud ConsoleでOAuthクライアントIDを発行し動作確認済み

## 動作確認
- [ ] ログイン画面の「Googleで続行」ボタンを押すとGoogle認証画面に遷移する
- [ ] Google認証後にログインできる
- [ ] 既存のメール/パスワードアカウントと同じGoogleアカウントでもログインできる