### PR TITLE
fix: 認証失敗時のリダイレクト先をログイン画面に変更

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -13,6 +13,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def failure
-    redirect_to root_path, alert: "Googleログインに失敗しました。"
+    redirect_to new_user_session_path, alert: "Googleログインに失敗しました。"
   end
 end


### PR DESCRIPTION
## Summary
- Google OAuth認証失敗・キャンセル時のリダイレクト先を`root_path`から`new_user_session_path`（ログイン画面）に変更

## Test plan
- [ ] Google認証をキャンセルした場合にログイン画面に戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)