### PR TITLE
feat: GitHub OAuthの設定を追加する（#192）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,4 +85,5 @@ gem "jsbundling-rails", "~> 1.3"
 gem "mini_magick"
 
 gem "omniauth-google-oauth2"
+gem "omniauth-github"
 gem "omniauth-rails_csrf_protection"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,9 @@ GEM
       logger
       rack (>= 2.2.3)
       rack-protection
+    omniauth-github (2.0.1)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
     omniauth-google-oauth2 (1.2.2)
       jwt (>= 2.9.2)
       oauth2 (~> 2.0)
@@ -400,6 +403,7 @@ DEPENDENCIES
   jsbundling-rails (~> 1.3)
   letter_opener_web
   mini_magick
+  omniauth-github
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   pg (~> 1.1)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: [:google_oauth2]
+         :omniauthable, omniauth_providers: [:google_oauth2, :github]
   
   has_many :records, dependent: :destroy
   has_many :activities, dependent: :destroy

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -275,6 +275,9 @@ Devise.setup do |config|
   config.omniauth :google_oauth2,
                   ENV.fetch("GOOGLE_CLIENT_ID", nil),
                   ENV.fetch("GOOGLE_CLIENT_SECRET", nil)
+  config.omniauth :github,
+                  ENV.fetch("GITHUB_CLIENT_ID", nil),
+                  ENV.fetch("GITHUB_CLIENT_SECRET", nil)
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
## 概要
- `omniauth-github` gemを追加
- `config/initializers/devise.rb` にGitHubプロバイダ設定を追加
- `User`モデルの`omniauth_providers`に`:github`を追加

## 動作確認
- [ ] DeviseがGitHubをプロバイダとして認識する