### PR TITLE
feat: OmniAuthCallbacksControllerにgithubアクションを追加（#193）

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -12,7 +12,20 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
+  def github
+    auth = request.env["omniauth.auth"]
+    @user = User.from_omniauth(auth)
+
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication
+      set_flash_message(:notice, :success, kind: "GitHub") if is_navigational_format?
+    else
+      session["devise.github_data"] = auth.except(:extra)
+      redirect_to new_user_registration_url, alert: @user.errors.full_messages.join(", ")
+    end
+  end
+
   def failure
-    redirect_to new_user_session_path, alert: "Googleログインに失敗しました。"
+    redirect_to new_user_session_path, alert: "ログインに失敗しました。"
   end
 end


### PR DESCRIPTION
## 概要
- `Users::OmniauthCallbacksController`に`github`アクションを追加
- Google同様、認証後にログインまたは登録画面へリダイレクト
- `failure`のメッセージをGitHubにも対応した汎用メッセージに変更

## 動作確認
- [ ] GitHub認証後にログインできる