### PR TITLE
feat: User.from_omniauthをGitHub対応に拡張する（#194）

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,17 +16,21 @@ class User < ApplicationRecord
     user = find_by(provider: auth.provider, uid: auth.uid)
     return user if user
 
-    user = find_by(email: auth.info.email)
+    email = auth.info.email.presence || "#{auth.provider}_#{auth.uid}@example.invalid"
+
+    user = find_by(email: email)
     if user
       user.update(provider: auth.provider, uid: auth.uid)
       return user
     end
 
+    name = (auth.info.name.presence || auth.info.nickname.to_s).slice(0, 20)
+
     create(
       provider: auth.provider,
       uid: auth.uid,
-      email: auth.info.email,
-      name: auth.info.name.to_s.slice(0, 20),
+      email: email,
+      name: name,
       password: Devise.friendly_token[0, 20]
     )
   end


### PR DESCRIPTION
## 概要
- `email`が取得できない場合に`github_<uid>@example.invalid`の仮メールを自動生成
- `name`が空の場合はGitHubの`nickname`（ユーザー名）にフォールバック
- Google OAuthも同じメソッドを使うため、両方で動作する

## 動作確認
- [ ] GitHubでemailが非公開のアカウントでもログインできる
- [ ] 2回目以降のログインは既存ユーザーが返される