### PR TITLE
feat: 部分テンプレにGitHubボタンを追加する（#195）

### DIFF
--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -61,7 +61,8 @@
   }
 }
 
-.oauth-google-btn {
+.oauth-google-btn,
+.oauth-github-btn {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/app/views/shared/_oauth_buttons.html.erb
+++ b/app/views/shared/_oauth_buttons.html.erb
@@ -4,7 +4,7 @@
   </div>
   <%= button_to user_google_oauth2_omniauth_authorize_path,
         method: :post,
-        class: "btn btn-outline-dark w-100 oauth-google-btn",
+        class: "btn btn-outline-dark w-100 oauth-google-btn mb-2",
         data: { turbo: false } do %>
     <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 48 48" class="me-2">
       <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
@@ -14,5 +14,14 @@
       <path fill="none" d="M0 0h48v48H0z"/>
     </svg>
     Googleで続行
+  <% end %>
+  <%= button_to user_github_omniauth_authorize_path,
+        method: :post,
+        class: "btn btn-outline-dark w-100 oauth-github-btn",
+        data: { turbo: false } do %>
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" class="me-2" fill="currentColor">
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.605-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 21.795 24 17.295 24 12c0-6.63-5.37-12-12-12"/>
+    </svg>
+    GitHubで続行
   <% end %>
 </div>


### PR DESCRIPTION
## 概要
- `_oauth_buttons.html.erb`にGitHubで続行ボタンを追加
- GoogleボタンとGitHubボタンでCSSクラスを共通化

## 動作確認
- [ ] ログイン画面・登録画面にGitHubボタンが表示される
- [ ] ボタンを押すとGitHub認証画面に遷移する

🤖 Generated with [Claude Code](https://claude.com/claude-code)