### PR TITLE
feat: X(Twitter)用のGem導入とDevise設定を追加する（#197）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,4 +86,5 @@ gem "mini_magick"
 
 gem "omniauth-google-oauth2"
 gem "omniauth-github"
+gem "omniauth-twitter"
 gem "omniauth-rails_csrf_protection"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,13 @@ GEM
     nio4r (2.7.5)
     nokogiri (1.18.10-x86_64-linux-gnu)
       racc (~> 1.4)
+    oauth (1.1.3)
+      base64 (~> 0.1)
+      oauth-tty (~> 1.0, >= 1.0.6)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1, >= 1.1.9)
+    oauth-tty (1.0.6)
+      version_gem (~> 1.1, >= 1.1.9)
     oauth2 (2.0.18)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
@@ -222,12 +229,19 @@ GEM
       oauth2 (~> 2.0)
       omniauth (~> 2.0)
       omniauth-oauth2 (~> 1.8)
+    omniauth-oauth (1.2.1)
+      oauth
+      omniauth (>= 1.0, < 3)
+      rack (>= 1.6.2, < 4)
     omniauth-oauth2 (1.9.0)
       oauth2 (>= 2.0.2, < 3)
       omniauth (~> 2.0)
     omniauth-rails_csrf_protection (2.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    omniauth-twitter (1.4.0)
+      omniauth-oauth (~> 1.1)
+      rack
     orm_adapter (0.5.0)
     parallel (1.27.0)
     parser (3.3.10.0)
@@ -406,6 +420,7 @@ DEPENDENCIES
   omniauth-github
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
+  omniauth-twitter
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.6)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: [:google_oauth2, :github]
+         :omniauthable, omniauth_providers: [:google_oauth2, :github, :twitter]
   
   has_many :records, dependent: :destroy
   has_many :activities, dependent: :destroy

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -278,6 +278,9 @@ Devise.setup do |config|
   config.omniauth :github,
                   ENV.fetch("GITHUB_CLIENT_ID", nil),
                   ENV.fetch("GITHUB_CLIENT_SECRET", nil)
+  config.omniauth :twitter,
+                  ENV.fetch("X_API_KEY", nil),
+                  ENV.fetch("X_API_SECRET", nil)
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
## 概要
- `omniauth-twitter` gemを追加
- `config/initializers/devise.rb` にTwitterプロバイダ設定を追加
- `User`モデルの`omniauth_providers`に`:twitter`を追加

## 動作確認
- [ ] DeviseがTwitterをプロバイダとして認識する