### PR TITLE
feat: OmniAuthCallbacksControllerにtwitterアクションを追加する（#198）

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -25,6 +25,19 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
+  def twitter
+    auth = request.env["omniauth.auth"]
+    @user = User.from_omniauth(auth)
+
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication
+      set_flash_message(:notice, :success, kind: "X") if is_navigational_format?
+    else
+      session["devise.twitter_data"] = auth.except(:extra)
+      redirect_to new_user_registration_url, alert: @user.errors.full_messages.join(", ")
+    end
+  end
+
   def failure
     redirect_to new_user_session_path, alert: "ログインに失敗しました。"
   end


### PR DESCRIPTION
## 概要
- `Users::OmniauthCallbacksController`に`twitter`アクションを追加
- GitHubと同様の実装でX認証後にログインまたは登録画面へリダイレクト

## 動作確認
- [ ] X認証後にログインできる

