### PR TITLE
feat: ユーザー登録画面のレスポンシブ対応（#202）

### DIFF
--- a/app/assets/stylesheets/login.scss
+++ b/app/assets/stylesheets/login.scss
@@ -1,3 +1,39 @@
+.top-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.top-inner-text {
+  text-align: center;
+  margin-bottom: 0.5rem;
+
+  h1 {
+    font-size: 1.6rem;
+    font-weight: bold;
+    color: #1e1b4b;
+  }
+}
+
+.top-form {
+  width: 100%;
+  max-width: 420px;
+  background: #fff;
+  padding: 1.8rem;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  margin-top: 1rem;
+
+  .form-control {
+    margin-bottom: 0.7rem;
+  }
+
+  .text-center {
+    margin-top: 1rem;
+  }
+}
+
 .login-form {
   width: 100%;
   max-width: 380px;


### PR DESCRIPTION
## 概要
- `.top-wrapper` / `.top-inner-text` / `.top-form` のCSSを追加
- ログイン画面と同じカードスタイルを登録画面にも適用
- 375px〜PCサイズで崩れないことを確認

## 動作確認
- [ ] 375pxで登録画面が崩れない
- [ ] OAuthボタンが正しく表示される