### PR TITLE
feat: ログイン画面のレスポンシブ対応（#203）

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -14,8 +14,8 @@
         <%= f.label :password, "パスワード", class: "form-label"  %>
         <%= f.password_field :password, autocomplete: "new-password", class: "form-control" %>
       </div>
-      <div class="actions">
-        <%= f.submit "ログイン", class: "btn btn-success btn-lg" %>
+      <div class="actions d-grid">
+        <%= f.submit "ログイン", class: "btn btn-success btn-lg w-100" %>
       </div>
       <div class="links">
         <%= link_to "新規登録はこちら", new_user_registration_path, class: "signup-link-btn" %>


### PR DESCRIPTION
## 概要
- ログインボタンを`d-grid w-100`でフル幅に変更
- 375pxで崩れないことを確認済み

## 動作確認
- [ ] 375pxでログイン画面が崩れない
- [ ] ログインボタンがフル幅で表示される