### PR TITLE
feat: 週次サマリーをカード表示・テーブル横スクロール対応（#121）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -644,6 +644,36 @@ html, body {
   flex-shrink: 0;
 }
 
+.weekly-summary-cards {
+  display: flex;
+  gap: 12px;
+  width: 100%;
+  margin: 8px 0;
+}
+
+.weekly-summary-card {
+  flex: 1;
+  background: #f5f3ff;
+  border-radius: 12px;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.weekly-summary-label {
+  font-size: 0.75rem;
+  color: #6366f1;
+  font-weight: bold;
+}
+
+.weekly-summary-value {
+  font-size: 1.2rem;
+  font-weight: bold;
+  color: #1e1b4b;
+}
+
 .weekly-goal {
   margin-top: 16px;
   padding: 12px 16px;

--- a/app/javascript/react/weekly/WeeklyApp.jsx
+++ b/app/javascript/react/weekly/WeeklyApp.jsx
@@ -75,8 +75,16 @@ export default function WeeklyApp() {
                             </li>
                         ))}
                     </ul>
-                    <p>● 今週の合計：{formatMinutes(data.total_minutes)}</p>
-                    <p>🔥 ストリーク：{data.streak_days}日</p>
+                    <div className="weekly-summary-cards">
+                        <div className="weekly-summary-card">
+                            <span className="weekly-summary-label">今週の合計</span>
+                            <span className="weekly-summary-value">{formatMinutes(data.total_minutes)}</span>
+                        </div>
+                        <div className="weekly-summary-card">
+                            <span className="weekly-summary-label">🔥 ストリーク</span>
+                            <span className="weekly-summary-value">{data.streak_days}日</span>
+                        </div>
+                    </div>
 
                     <button className="weekly-goal-btn" onClick={() => setIsGoalModalOpen(true)}>
                         🎯 今週の目標を設定

--- a/app/javascript/react/weekly/WeeklyTable.jsx
+++ b/app/javascript/react/weekly/WeeklyTable.jsx
@@ -2,27 +2,29 @@ import React from "react";
 
 export default function WeeklyTable({ summary, formatMinutes }) {
     return (
-        <table>
-            <thead>
-                <tr>
-                    <th>カテゴリ</th>
-                    <th>回数</th>
-                    <th>実施時間</th>
-                    <th>割合</th>
-                    <th>先週比</th>
-                </tr>
-            </thead>
-            <tbody>
-                {summary.map((s) => (
-                    <tr key={s.activity_id}>
-                        <td>{s.activity_name}</td>
-                        <td>{s.count}回</td>
-                        <td>{formatMinutes(s.total_minutes)}</td>
-                        <td>{s.percentage}%</td>
-                        <td>-</td>
+        <div style={{ overflowX: "auto", width: "100%" }}>
+            <table style={{ width: "max-content", minWidth: "100%" }}>
+                <thead>
+                    <tr>
+                        <th>カテゴリ</th>
+                        <th>回数</th>
+                        <th>実施時間</th>
+                        <th>割合</th>
+                        <th>先週比</th>
                     </tr>
-                ))}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {summary.map((s) => (
+                        <tr key={s.activity_id}>
+                            <td>{s.activity_name}</td>
+                            <td>{s.count}回</td>
+                            <td>{formatMinutes(s.total_minutes)}</td>
+                            <td>{s.percentage}%</td>
+                            <td>-</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
     );
 }


### PR DESCRIPTION
## 概要
- 今週の合計・ストリークをカード形式で表示
- WeeklyTableに`overflow-x: auto`を追加して横スクロール対応

## 動作確認
- [ ] 375pxでサマリーカードが読みやすい
- [ ] テーブルが横スクロールできる