### PR TITLE
feat: テストを追加・修正する（#204）

### DIFF
--- a/app/models/weekly_goal.rb
+++ b/app/models/weekly_goal.rb
@@ -1,4 +1,6 @@
 class WeeklyGoal < ApplicationRecord
   belongs_to :user
   belongs_to :activity
+
+  validates :week_start, uniqueness: { scope: :user_id }
 end

--- a/test/factories/activities.rb
+++ b/test/factories/activities.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :activity do
     association :user
-    name   { Faker::Hobby.activity.slice(0, 20) }
+    sequence(:name) { |n| "Activity #{n}" }
     active { true }
   end
 end

--- a/test/factories/weekly_goals.rb
+++ b/test/factories/weekly_goals.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :weekly_goal do
+    association :user
+    association :activity
+    percentage { 50 }
+    week_start { Date.current.beginning_of_week(:monday) }
+  end
+end

--- a/test/models/activity_test.rb
+++ b/test/models/activity_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActivityTest < ActiveSupport::TestCase
+  test 'valid activity can be created with factory' do
+    assert build(:activity).valid?
+  end
+
+  test 'activity without user is valid (optional)' do
+    assert build(:activity, user: nil).valid?
+  end
+
+  test 'active defaults to true' do
+    activity = create(:activity)
+    assert activity.active
+  end
+
+  test 'active can be set to false' do
+    activity = create(:activity, active: false)
+    assert_not activity.active
+  end
+
+  test 'destroying activity destroys associated records' do
+    activity = create(:activity)
+    create(:record, user: activity.user, activity: activity)
+    assert_difference('Record.count', -1) { activity.destroy }
+  end
+end

--- a/test/models/record_test.rb
+++ b/test/models/record_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class RecordTest < ActiveSupport::TestCase
+  setup do
+    @user     = create(:user)
+    @activity = create(:activity, user: @user)
+  end
+
+  test 'valid record can be created with factory' do
+    assert create(:record, user: @user, activity: @activity).valid?
+  end
+
+  test 'activity_id is required' do
+    assert_not build(:record, user: @user, activity: nil).valid?
+  end
+
+  test 'user is required' do
+    assert_not build(:record, user: nil, activity: @activity).valid?
+  end
+
+  test 'logged_at is set automatically if blank' do
+    record = create(:record, user: @user, activity: @activity, logged_at: nil)
+    assert_not_nil record.logged_at
+  end
+
+  test 'logged_at is not overwritten if already set' do
+    time   = 3.days.ago
+    record = create(:record, user: @user, activity: @activity, logged_at: time)
+    assert_in_delta time, record.logged_at, 1.second
+  end
+
+  test 'to_param returns public_id' do
+    record = create(:record, user: @user, activity: @activity)
+    assert_equal record.public_id.to_s, record.to_param
+  end
+
+  test 'in_week scope returns records within the week' do
+    today     = Date.current
+    this_week = create(:record, user: @user, activity: @activity, logged_at: today.beginning_of_week(:monday))
+    last_week = create(:record, user: @user, activity: @activity, logged_at: today.beginning_of_week(:monday) - 1.week)
+    results   = Record.in_week(today)
+    assert_includes results, this_week
+    assert_not_includes results, last_week
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,20 +1,76 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'ostruct'
 
 class UserTest < ActiveSupport::TestCase
+  # --- バリデーション ---
   test 'valid user can be created with factory' do
-    user = build(:user)
-    assert user.valid?
+    assert build(:user).valid?
   end
 
   test 'name is required' do
-    user = build(:user, name: nil)
-    assert_not user.valid?
+    assert_not build(:user, name: nil).valid?
   end
 
   test 'name cannot exceed 20 characters' do
-    user = build(:user, name: 'a' * 21)
-    assert_not user.valid?
+    assert_not build(:user, name: 'a' * 21).valid?
+  end
+
+  test 'name of exactly 20 characters is valid' do
+    assert build(:user, name: 'a' * 20).valid?
+  end
+
+  test 'email is required' do
+    assert_not build(:user, email: nil).valid?
+  end
+
+  test 'email must be unique' do
+    existing = create(:user)
+    assert_not build(:user, email: existing.email).valid?
+  end
+
+  # --- アソシエーション ---
+  test 'destroying user destroys associated records' do
+    user     = create(:user)
+    activity = create(:activity, user: user)
+    create(:record, user: user, activity: activity)
+    assert_difference('Record.count', -1) { user.destroy }
+  end
+
+  test 'destroying user destroys associated activities' do
+    user = create(:user)
+    create(:activity, user: user)
+    assert_difference('Activity.count', -1) { user.destroy }
+  end
+
+  # --- from_omniauth ---
+  test 'from_omniauth returns existing user by provider and uid' do
+    user = create(:user, provider: 'github', uid: '12345')
+    auth = mock_auth('github', '12345', user.email)
+    assert_equal user, User.from_omniauth(auth)
+  end
+
+  test 'from_omniauth links existing email account' do
+    user = create(:user, provider: nil, uid: nil)
+    auth = mock_auth('github', '99999', user.email)
+    result = User.from_omniauth(auth)
+    assert_equal user.id, result.id
+    assert_equal 'github', result.provider
+  end
+
+  test 'from_omniauth creates new user when not found' do
+    auth = mock_auth('github', 'new123', 'new@example.com')
+    assert_difference('User.count', 1) { User.from_omniauth(auth) }
+  end
+
+  private
+
+  def mock_auth(provider, uid, email, name = 'Test User')
+    OpenStruct.new(
+      provider: provider,
+      uid: uid,
+      info: OpenStruct.new(email: email, name: name, nickname: nil)
+    )
   end
 end

--- a/test/models/weekly_goal_test.rb
+++ b/test/models/weekly_goal_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class WeeklyGoalTest < ActiveSupport::TestCase
+  test 'valid weekly_goal can be created with factory' do
+    assert build(:weekly_goal).valid?
+  end
+
+  test 'user is required' do
+    assert_not build(:weekly_goal, user: nil).valid?
+  end
+
+  test 'activity is required' do
+    assert_not build(:weekly_goal, activity: nil).valid?
+  end
+
+  test 'percentage defaults to 50' do
+    goal = create(:weekly_goal)
+    assert_equal 50, goal.percentage
+  end
+
+  test 'week_start must be unique per user' do
+    goal = create(:weekly_goal)
+    duplicate = build(:weekly_goal, user: goal.user, week_start: goal.week_start)
+    assert_not duplicate.valid?
+  end
+end


### PR DESCRIPTION
## Summary
- Activity / Record / WeeklyGoal のモデルテストを追加（計28件）
- WeeklyGoalに `week_start` の一意性バリデーションを追加
- FactoryBotの `build` / `create` の扱いを修正

## Test plan
- [x] `bundle exec rails test test/models/` で28件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)