### PR TITLE
fix: ダッシュボードの計測・表示バグを修正し、円グラフの色を行動ごとに固定する

### DIFF
--- a/app/controllers/api/dashboard_controller.rb
+++ b/app/controllers/api/dashboard_controller.rb
@@ -11,10 +11,19 @@ class Api::DashboardController < ApplicationController
                        .where(logged_at: start_at..end_at)
                        .order(:logged_at)
 
+    # 日付をまたいだ直後も表示できるよう、今日の開始と6時間前の早い方を起点にする
+    current_log_cutoff = [now.beginning_of_day, now - 6.hours].min
+    current_log = current_user.records
+                               .includes(:activity)
+                               .where(ended_at: nil)
+                               .where("logged_at >= ?", current_log_cutoff)
+                               .order(logged_at: :desc)
+                               .first
+
     render json: {
       logs: build_logs_json(logs),
       summary_per_category: summarize_per_activity(logs, now),
-      current_log: logs.select { |l| l.ended_at.nil? }.last&.then { |l| build_record_json(l) },
+      current_log: current_log&.then { |l| build_record_json(l) },
       now: now.iso8601
     }
   end
@@ -41,18 +50,18 @@ class Api::DashboardController < ApplicationController
   def summarize_per_activity(logs, now)
     return [] if logs.empty?
 
-    sums = Hash.new { |h, k| h[k] = { total_minutes: 0, count: 0, activity_name: nil } }
+    sums = Hash.new { |h, k| h[k] = { total_seconds: 0, count: 0, activity_name: nil } }
 
     logs.each_with_index do |log, i|
-      next_time = logs[i + 1]&.logged_at || now
+      # ended_atなし・次のログもない場合は進行中とみなし0秒（フロントのbuildLiveSummaryが加算）
+      end_time = log.ended_at || logs[i + 1]&.logged_at || log.logged_at
 
-      diff_minutes = ((next_time - log.logged_at) / 60).floor
-      diff_minutes = 0 if diff_minutes.negative?
-      diff_minutes = [diff_minutes, 360].min
+      diff_seconds = [(end_time - log.logged_at).to_i, 0].max
+      diff_seconds = [diff_seconds, 43200].min
 
       key = log.activity.public_id
 
-      sums[key][:total_minutes] += diff_minutes
+      sums[key][:total_seconds] += diff_seconds
       sums[key][:count] += 1
       sums[key][:activity_name] ||= log.activity.name
     end
@@ -61,9 +70,9 @@ class Api::DashboardController < ApplicationController
       {
         activity_id: activity_id,
         activity_name: v[:activity_name],
-        total_minutes: v[:total_minutes],
+        total_seconds: v[:total_seconds],
         count: v[:count]
       }
-    end.sort_by { |h| -h[:total_minutes] }
+    end.sort_by { |h| -h[:total_seconds] }
   end
 end

--- a/app/controllers/api/dashboard_logs_controller.rb
+++ b/app/controllers/api/dashboard_logs_controller.rb
@@ -3,10 +3,18 @@ class Api::DashboardLogsController < ApplicationController
 
   def create
     activity = Activity.find_by!(public_id: params[:activity_id])
+    now = trusted_client_time(params[:logged_at])
+
+    cutoff = [now.beginning_of_day, now - 6.hours].min
+    current_user.records
+                .where(ended_at: nil)
+                .where("logged_at >= ?", cutoff)
+                .update_all(ended_at: now)
+
     record = current_user.records.new(
       activity:  activity,
       memo:      params[:memo],
-      logged_at: Time.zone.now
+      logged_at: now
     )
     if record.save
       now = Time.current
@@ -30,6 +38,15 @@ class Api::DashboardLogsController < ApplicationController
 
   private
 
+  def trusted_client_time(time_str)
+    return Time.zone.now if time_str.blank?
+    client_time = Time.zone.parse(time_str)
+    # サーバー時刻と30秒以上ずれていれば無視
+    (client_time - Time.zone.now).abs <= 30 ? client_time : Time.zone.now
+  rescue
+    Time.zone.now
+  end
+
   def build_record_json(record, activity)
     {
       id: record.public_id,
@@ -45,12 +62,13 @@ class Api::DashboardLogsController < ApplicationController
 
   def summarize_per_activity(logs, now)
     return [] if logs.empty?
-    sums = Hash.new { |h, k| h[k] = { total_minutes: 0, count: 0, activity_name: nil } }
+    sums = Hash.new { |h, k| h[k] = { total_seconds: 0, count: 0, activity_name: nil } }
     logs.each_with_index do |log, i|
-      next_time = logs[i + 1]&.logged_at || now
-      diff_minutes = [[((next_time - log.logged_at) / 60).floor, 0].max, 360].min
+      end_time = log.ended_at || logs[i + 1]&.logged_at || log.logged_at
+      diff_seconds = [(end_time - log.logged_at).to_i, 0].max
+      diff_seconds = [diff_seconds, 43200].min
       key = log.activity.public_id
-      sums[key][:total_minutes] += diff_minutes
+      sums[key][:total_seconds] += diff_seconds
       sums[key][:count] += 1
       sums[key][:activity_name] ||= log.activity.name
     end
@@ -58,9 +76,9 @@ class Api::DashboardLogsController < ApplicationController
       {
         activity_id: activity_id,
         activity_name: v[:activity_name],
-        total_minutes: v[:total_minutes],
+        total_seconds: v[:total_seconds],
         count: v[:count]
       }
-    end.sort_by { |h| -h[:total_minutes] }
+    end.sort_by { |h| -h[:total_seconds] }
   end
 end

--- a/app/controllers/api/dashboard_stop_controller.rb
+++ b/app/controllers/api/dashboard_stop_controller.rb
@@ -2,8 +2,12 @@ class Api::DashboardStopController < ApplicationController
   before_action :authenticate_user!
 
   def create
+    now = trusted_client_time(params[:ended_at])
+    cutoff = [now.beginning_of_day, now - 6.hours].min
     current_log = current_user.records
+                               .includes(:activity)
                                .where(ended_at: nil)
+                               .where("logged_at >= ?", cutoff)
                                .order(logged_at: :desc)
                                .first
 
@@ -12,8 +16,56 @@ class Api::DashboardStopController < ApplicationController
       return
     end
 
-    current_log.update!(ended_at: Time.current)
+    current_log.update!(ended_at: now)
 
-    render json: { ok: true }, status: :ok
+    logs = current_user.records
+                       .includes(:activity)
+                       .where(logged_at: now.beginning_of_day..now.end_of_day)
+                       .order(:logged_at)
+
+    render json: {
+      ok: true,
+      record: build_record_json(current_log),
+      summary_per_category: summarize_per_activity(logs),
+      now: now.iso8601
+    }, status: :ok
+  end
+
+  private
+
+  def trusted_client_time(time_str)
+    return Time.zone.now if time_str.blank?
+    client_time = Time.zone.parse(time_str)
+    (client_time - Time.zone.now).abs <= 30 ? client_time : Time.zone.now
+  rescue
+    Time.zone.now
+  end
+
+  def build_record_json(record)
+    {
+      id: record.public_id,
+      activity: { id: record.activity.public_id, name: record.activity.name },
+      logged_at: record.logged_at.in_time_zone("Tokyo").iso8601,
+      ended_at: record.ended_at&.in_time_zone("Tokyo")&.iso8601,
+      memo: record.memo
+    }
+  end
+
+  def summarize_per_activity(logs)
+    return [] if logs.empty?
+    sums = Hash.new { |h, k| h[k] = { total_seconds: 0, count: 0, activity_name: nil } }
+    logs.each_with_index do |log, i|
+      end_time = log.ended_at || logs[i + 1]&.logged_at || log.logged_at
+      diff_seconds = [(end_time - log.logged_at).to_i, 0].max
+      diff_seconds = [diff_seconds, 43200].min
+      key = log.activity.public_id
+      sums[key][:total_seconds] += diff_seconds
+      sums[key][:count] += 1
+      sums[key][:activity_name] ||= log.activity.name
+    end
+    sums.map do |activity_id, v|
+      { activity_id: activity_id, activity_name: v[:activity_name],
+        total_seconds: v[:total_seconds], count: v[:count] }
+    end.sort_by { |h| -h[:total_seconds] }
   end
 end

--- a/app/javascript/react/dashboard/DashboardApp.jsx
+++ b/app/javascript/react/dashboard/DashboardApp.jsx
@@ -39,12 +39,26 @@ export default function DashboardApp() {
   }, [dashboard?.current_log]);
 
   async function handleSubmit({ activityId, memo, onSuccess }) {
+    // 計測中はタイマーと同じ now を使い、停止後は new Date()（now が凍結しているため）
+    const loggedAt = dashboard?.current_log ? now.toISOString() : new Date().toISOString();
+
+    // APIを待たず即座に前のログを終了・タイマーを止める
+    setDashboard((prev) => {
+      if (!prev?.current_log) return prev;
+      return {
+        ...prev,
+        logs: (prev?.logs ?? []).map((l) =>
+          l.id === prev.current_log.id ? { ...l, ended_at: loggedAt } : l
+        ),
+        current_log: null,
+      };
+    });
+
     setError(null);
     try {
       setIsSubmitting(true);
-      const data = await postLog({ activityId, memo });
+      const data = await postLog({ activityId, memo, loggedAt });
 
-      // POSTレスポンスで直接stateを更新（loadAll不要）
       setDashboard((prev) => ({
         ...prev,
         logs: [...(prev?.logs ?? []), data.record],
@@ -53,8 +67,7 @@ export default function DashboardApp() {
         now: data.now,
       }));
 
-      setNow(new Date()); // タイマーリセット
-
+      setNow(new Date());
       onSuccess?.();
     } catch (e) {
       console.error(e);
@@ -65,10 +78,13 @@ export default function DashboardApp() {
   }
 
   async function handleStopTimer() {
+    const endedAt = now.toISOString();
     try {
-      await stopLog();
+      const data = await stopLog({ endedAt });
       setDashboard((prev) => ({
         ...prev,
+        logs: (prev?.logs ?? []).map((l) => l.id === data.record.id ? data.record : l),
+        summary_per_category: data.summary_per_category,
         current_log: null,
       }));
     } catch (e) {

--- a/app/javascript/react/dashboard/api.js
+++ b/app/javascript/react/dashboard/api.js
@@ -19,7 +19,7 @@ export async function fetchActivities() {
   return await res.json();
 }
 
-export async function postLog({ activityId, memo }) {
+export async function postLog({ activityId, memo, loggedAt }) {
   const res = await fetch("/api/dashboard/logs", {
     method: "POST",
     headers: {
@@ -28,8 +28,9 @@ export async function postLog({ activityId, memo }) {
       "X-CSRF-Token": csrfToken(),
     },
     body: JSON.stringify({
-      activity_id: activityId, // ← ここは snake_case
+      activity_id: activityId,
       memo,
+      logged_at: loggedAt,
     }),
   });
 
@@ -42,7 +43,7 @@ export async function postLog({ activityId, memo }) {
   return data;
 }
 
-export async function stopLog() {
+export async function stopLog({ endedAt } = {}) {
   const res = await fetch("/api/dashboard/stop", {
     method: "POST",
     headers: {
@@ -50,6 +51,7 @@ export async function stopLog() {
       Accept: "application/json",
       "X-CSRF-Token": csrfToken(),
     },
+    body: JSON.stringify({ ended_at: endedAt }),
   });
   const data = await res.json().catch(() => ({}));
   if (!res.ok || data.ok === false) {

--- a/app/javascript/react/dashboard/components/CurrentStatus.jsx
+++ b/app/javascript/react/dashboard/components/CurrentStatus.jsx
@@ -11,7 +11,7 @@ export default function CurrentStatus({ dashboard, activities, now, onStop }) {
     ? Math.max(0, Math.floor((currentNow - new Date(currentLog.logged_at)) / 1000))
     : 0;
 
-  const cappedSeconds = Math.min(elapsedSeconds, 21600);
+  const cappedSeconds = Math.min(elapsedSeconds, 43200);
   const hours = Math.floor(cappedSeconds / 3600);
   const minutes = Math.floor((cappedSeconds % 3600) / 60);
   const seconds = cappedSeconds % 60;

--- a/app/javascript/react/dashboard/components/SummaryStatus.jsx
+++ b/app/javascript/react/dashboard/components/SummaryStatus.jsx
@@ -1,7 +1,19 @@
 import React from "react";
 import DonutChart from "./charts/DonutChart";
 
-const COLORS = ["#818cf8", "#fb923c", "#34d399", "#f43f5e", "#900ce9"];
+// ゴールデンアングル(137.508°)で並べると隣り合う番号でも色相が大きく離れる
+const COLORS = Array.from({ length: 30 }, (_, i) =>
+  `hsl(${Math.round((i * 137.508) % 360)}, 65%, 52%)`
+);
+
+function activityColor(activityId) {
+  let hash = 0;
+  for (let i = 0; i < activityId.length; i++) {
+    hash = ((hash << 5) - hash) + activityId.charCodeAt(i);
+    hash |= 0;
+  }
+  return COLORS[Math.abs(hash) % COLORS.length];
+}
 
 const MESSAGES = ["ナイスペース！", "いい調子だよ！", "継続は力なり！", "今日もお疲れ様！"];
 
@@ -13,16 +25,29 @@ function getMessage(logs) {
 
 function buildLiveSummary(summary, currentLog, now) {
   if (!currentLog || !summary.length) return summary;
-  const elapsedMinutes = Math.min(
-    Math.floor((now - new Date(currentLog.logged_at)) / 1000 / 60),
-    360
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+  const logStart = new Date(currentLog.logged_at);
+  const effectiveStart = logStart > startOfToday ? logStart : startOfToday;
+  const elapsedSeconds = Math.min(
+    Math.floor((now - effectiveStart) / 1000),
+    43200
   );
   return summary.map((s) => {
     if (s.activity_id === currentLog.activity.id) {
-      return { ...s, total_minutes: s.total_minutes + elapsedMinutes };
+      return { ...s, total_seconds: s.total_seconds + elapsedSeconds };
     }
     return s;
   });
+}
+
+function formatSeconds(seconds) {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) return `${h}時間${m}分`;
+  if (m > 0) return s > 0 ? `${m}分${s}秒` : `${m}分`;
+  return `${s}秒`;
 }
 
 export default function SummaryStatus({ dashboard, now }) {
@@ -32,13 +57,13 @@ export default function SummaryStatus({ dashboard, now }) {
   const currentNow = now ?? new Date();
 
   const liveSummary = buildLiveSummary(summary, currentLog, currentNow);
-  const total = liveSummary.reduce((acc, x) => acc + x.total_minutes, 0);
-  const liveSummaryFiltered = liveSummary.filter((s) => s.total_minutes > 0);
+  const total = liveSummary.reduce((acc, x) => acc + x.total_seconds, 0);
+  const liveSummaryFiltered = liveSummary.filter((s) => s.total_seconds > 0);
 
-  // 中心に表示する合計時間
-  const totalH = Math.floor(total / 60);
-  const totalM = total % 60;
-  const totalStr = totalH > 0 ? `${totalH}h${totalM}m` : `${totalM}m`;
+  const totalH = Math.floor(total / 3600);
+  const totalM = Math.floor((total % 3600) / 60);
+  const totalS = total % 60;
+  const totalStr = totalH > 0 ? `${totalH}h${totalM}m` : totalM > 0 ? `${totalM}m${totalS > 0 ? `${totalS}s` : ""}` : `${totalS}s`;
 
   return (
     <div style={{
@@ -72,8 +97,8 @@ export default function SummaryStatus({ dashboard, now }) {
             <div className="summary-donut" style={{ position: "relative", flexShrink: 0 }}>
               <DonutChart
                 labels={liveSummaryFiltered.map((s) => s.activity_name)}
-                values={liveSummaryFiltered.map((s) => s.total_minutes)}
-                colors={liveSummaryFiltered.map((_, i) => COLORS[i % COLORS.length])}
+                values={liveSummaryFiltered.map((s) => s.total_seconds)}
+                colors={liveSummaryFiltered.map((s) => activityColor(s.activity_id))}
                 size={160}
               />
               <div style={{
@@ -88,17 +113,15 @@ export default function SummaryStatus({ dashboard, now }) {
 
             {/* レジェンド */}
             <div className="summary-legend" style={{ flex: 1, display: "flex", flexDirection: "column", gap: 8 }}>
-              {liveSummary.map((s, i) => {
-                const h = Math.floor(s.total_minutes / 60);
-                const m = s.total_minutes % 60;
-                const timeStr = h > 0 ? `${h}時間${m}分` : `${m}分`;
-                const pct = total > 0 ? Math.round((s.total_minutes / total) * 100) : 0;
+              {liveSummary.map((s) => {
+                const timeStr = formatSeconds(s.total_seconds);
+                const pct = total > 0 ? Math.round((s.total_seconds / total) * 100) : 0;
                 return (
                   <div key={s.activity_id} style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 10px", borderRadius: 10, transition: "background 0.15s" }}
                     onMouseEnter={(e) => e.currentTarget.style.background = "rgba(238,242,255,0.6)"}
                     onMouseLeave={(e) => e.currentTarget.style.background = "transparent"}
                   >
-                    <div style={{ width: 10, height: 10, borderRadius: "50%", background: COLORS[i % COLORS.length], flexShrink: 0, boxShadow: "0 2px 4px rgba(0,0,0,0.15)" }} />
+                    <div style={{ width: 10, height: 10, borderRadius: "50%", background: activityColor(s.activity_id), flexShrink: 0, boxShadow: "0 2px 4px rgba(0,0,0,0.15)" }} />
                     <span style={{ fontSize: 12, color: "#334155", flex: 1, fontWeight: 700 }}>{s.activity_name}</span>
                     <span style={{ fontSize: 11, color: "#64748b", fontFamily: "monospace" }}>{timeStr}</span>
                     <span style={{ fontSize: 11, color: "#6366f1", background: "#eef2ff", padding: "2px 6px", borderRadius: 20, fontWeight: 700 }}>{pct}%</span>

--- a/app/javascript/react/dashboard/components/TodayHistory.jsx
+++ b/app/javascript/react/dashboard/components/TodayHistory.jsx
@@ -7,31 +7,38 @@ export default function TodayHistory({ logs, activities, now, dashboard }) {
   const sorted = [...logs].sort((a, b) => new Date(b.logged_at) - new Date(a.logged_at));
   const chronological = [...logs].sort((a, b) => new Date(a.logged_at) - new Date(b.logged_at));
 
+  function formatSeconds(seconds) {
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = seconds % 60;
+    if (h > 0) return `${h}時間${m}分`;
+    if (m > 0) return s > 0 ? `${m}分${s}秒` : `${m}分`;
+    return `${s}秒`;
+  }
+
   function getDuration(log) {
+    // ended_at が設定済みなら必ずそれを使う（next.logged_at より正確）
+    if (log.ended_at) {
+      const diff = Math.floor((new Date(log.ended_at) - new Date(log.logged_at)) / 1000);
+      if (diff <= 0) return null;
+      return formatSeconds(diff);
+    }
+
     const idx = chronological.findIndex((l) => l.id === log.id);
     const next = chronological[idx + 1];
 
     if (!next) {
-      if (log.ended_at) {
-        const diff = Math.floor((new Date(log.ended_at) - new Date(log.logged_at)) / 1000 / 60);
-        if (diff <= 0) return null;
-        const h = Math.floor(diff / 60);
-        const m = diff % 60;
-        return h > 0 ? `${h}時間${m}分` : `${m}分`;
-      }
       if (!currentLog || currentLog.id !== log.id) return null;
-      const diff = Math.floor((currentNow - new Date(log.logged_at)) / 1000);
+      const diff = Math.max(0, Math.floor((currentNow - new Date(log.logged_at)) / 1000));
       const h = Math.floor(diff / 3600);
       const m = Math.floor((diff % 3600) / 60);
       const s = diff % 60;
-      return h > 0 ? `${h}時間${m}分${s}秒` : `${m}分${s}秒`;
+      return h > 0 ? `${h}時間${m}分${s}秒` : m > 0 ? `${m}分${s}秒` : `${s}秒`;
     }
 
-    const diff = Math.floor((new Date(next.logged_at) - new Date(log.logged_at)) / 1000 / 60);
+    const diff = Math.floor((new Date(next.logged_at) - new Date(log.logged_at)) / 1000);
     if (diff <= 0) return null;
-    const h = Math.floor(diff / 60);
-    const m = diff % 60;
-    return h > 0 ? `${h}時間${m}分` : `${m}分`;
+    return formatSeconds(diff);
   }
 
   return (


### PR DESCRIPTION
## 概要

- 計測時間を分単位から秒単位に変更（表示・集計ともに対応）
- 「計測を止める」を押さずに別行動を記録した際、前の計測を正しく終了するよう修正
- タイマーが -1 秒からカウントされるバグを修正
- 「計測を止める」後に記録が画面から消えるバグを修正
- 止めた後に別行動を記録すると前の履歴の時間が増えるバグを修正（`ended_at` を `next.logged_at` より優先）
- クライアントタイムスタンプをサーバーに送信して正確な時刻を記録（30秒以内の誤差を許容）
- 日付またぎの計測に対応（6時間ウィンドウで `current_log` を取得）
- 円グラフの色を `activity_id` のハッシュ＋ゴールデンアングルパレットで行動ごとに固定

## 動作確認

- [ ] 行動を記録してタイマーが 0 秒からカウントされることを確認
- [ ] 「計測を止める」を押さずに別行動を記録し、前の履歴の時間が正しく止まることを確認
- [ ] 「計測を止める」→ 別行動を「記録する」の操作で前の履歴時間が増えないことを確認
- [ ] 「計測を止める」後にリロードせず記録が表示されることを確認
- [ ] 複数の行動を記録して円グラフの色が行動ごとに固定されることを確認
- [ ] ページリロード後も同じ行動が同じ色で表示されることを確認