### PR TITLE
fix: 週次記録画面を改善し、テストを追加する（#206）

### DIFF
--- a/app/controllers/api/weekly_controller.rb
+++ b/app/controllers/api/weekly_controller.rb
@@ -8,9 +8,12 @@ class Api::WeeklyController < ApplicationController
 
     logs    = current_user.records.in_week(base_date).includes(:activity).order(:logged_at)
     summary = WeeklySummaryService.new(logs).call
-    streak  = StreakService.new(current_user).call
+    streak  = StreakService.new(current_user, as_of: [week_end, Date.current].min).call
 
-    total_minutes = summary.sum { |s| s[:total_minutes] }
+    prev_logs    = current_user.records.in_week(week_start - 1.week).includes(:activity).order(:logged_at)
+    prev_summary = WeeklySummaryService.new(prev_logs).call
+
+    total_seconds = summary.sum { |s| s[:total_seconds] }
     weekly_goal = current_user.weekly_goals.find_by(week_start: week_start)
 
     goal_activity = weekly_goal ? Activity.find_by(id: weekly_goal.activity_id) : nil
@@ -24,8 +27,9 @@ class Api::WeeklyController < ApplicationController
     render json: {
       week_start:           week_start.iso8601,
       week_end:             week_end.iso8601,
-      total_minutes:        total_minutes,
+      total_seconds:        total_seconds,
       summary:              summary,
+      prev_summary:         prev_summary,
       streak_days:          streak,
       goal_activity_id:     weekly_goal&.activity_id,
       goal_activity_name:   goal_activity&.name,

--- a/app/javascript/react/activityColor.js
+++ b/app/javascript/react/activityColor.js
@@ -1,0 +1,12 @@
+const COLORS = Array.from({ length: 30 }, (_, i) =>
+  `hsl(${Math.round((i * 137.508) % 360)}, 65%, 52%)`
+);
+
+export function activityColor(activityId) {
+  let hash = 0;
+  for (let i = 0; i < activityId.length; i++) {
+    hash = ((hash << 5) - hash) + activityId.charCodeAt(i);
+    hash |= 0;
+  }
+  return COLORS[Math.abs(hash) % COLORS.length];
+}

--- a/app/javascript/react/dashboard/components/SummaryStatus.jsx
+++ b/app/javascript/react/dashboard/components/SummaryStatus.jsx
@@ -1,19 +1,6 @@
 import React from "react";
 import DonutChart from "./charts/DonutChart";
-
-// ゴールデンアングル(137.508°)で並べると隣り合う番号でも色相が大きく離れる
-const COLORS = Array.from({ length: 30 }, (_, i) =>
-  `hsl(${Math.round((i * 137.508) % 360)}, 65%, 52%)`
-);
-
-function activityColor(activityId) {
-  let hash = 0;
-  for (let i = 0; i < activityId.length; i++) {
-    hash = ((hash << 5) - hash) + activityId.charCodeAt(i);
-    hash |= 0;
-  }
-  return COLORS[Math.abs(hash) % COLORS.length];
-}
+import { activityColor } from "../../activityColor";
 
 const MESSAGES = ["ナイスペース！", "いい調子だよ！", "継続は力なり！", "今日もお疲れ様！"];
 

--- a/app/javascript/react/dashboard/components/charts/DonutChart.jsx
+++ b/app/javascript/react/dashboard/components/charts/DonutChart.jsx
@@ -35,9 +35,10 @@ export default function DonutChart({ labels, values, colors, size = 160 }) {
                 const total = context.dataset.data.reduce((a, b) => a + b, 0);
                 const value = context.parsed;
                 const pct = Math.round((value / total) * 100);
-                const h = Math.floor(value / 60);
-                const m = value % 60;
-                const timeStr = h > 0 ? `${h}時間${m}分` : `${m}分`;
+                const h = Math.floor(value / 3600);
+                const m = Math.floor((value % 3600) / 60);
+                const s = value % 60;
+                const timeStr = h > 0 ? `${h}時間${m}分` : m > 0 ? `${m}分${s > 0 ? `${s}秒` : ""}` : `${s}秒`;
                 return ` ${timeStr}（${pct}%）`;
               },
             },

--- a/app/javascript/react/weekly/WeeklyApp.jsx
+++ b/app/javascript/react/weekly/WeeklyApp.jsx
@@ -3,19 +3,21 @@ import { fetchWeekly } from "./api";
 import WeeklyChart from "./WeeklyChart";
 import WeeklyTable from "./WeeklyTable";
 import WeeklyGoalModal from "./WeeklyGoalModal";
+import { activityColor } from "../activityColor";
 
-const COLORS = ["#818cf8", "#fb923c", "#818cf8", "#f43f5e", "#900ce9"];
-
-function formatMinutes(minutes) {
-    const h = Math.floor(minutes / 60);
-    const m = minutes % 60;
-    return h > 0 ? `${h}時間${m}分` : `${m}分`;
+function formatSeconds(seconds) {
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = seconds % 60;
+    if (h > 0) return `${h}時間${m}分`;
+    if (m > 0) return s > 0 ? `${m}分${s}秒` : `${m}分`;
+    return `${s}秒`;
 }
 
 function buildWeeklyShareText(data) {
-    const total = formatMinutes(data.total_minutes);
+    const total = formatSeconds(data.total_seconds);
     const top = data.summary.slice(0,3)
-        .map((s) => `${s.activity_name}：${formatMinutes(s.total_minutes)}（${s.percentage}%）`)
+        .map((s) => `${s.activity_name}：${formatSeconds(s.total_seconds)}（${s.percentage}%）`)
         .join("\n");
     return `今週（${data.week_start} ～ ${data.week_end}）の勉強記録\n合計：${total}\n${top}\nストリーク：${data.streak_days}日\n#StudyKeeper\n`;
 }
@@ -68,17 +70,17 @@ export default function WeeklyApp() {
                     )}
                     <p className="weekly-card-title">今週の勉強時間の割合</p>
                     <ul className="weekly-legend">
-                        {data.summary.map((s, i) => (
+                        {data.summary.map((s) => (
                             <li key={s.activity_id} className="weekly-legend-item">
-                                <span className="weekly-legend-color" style={{ backgroundColor: COLORS[i % COLORS.length] }}></span>
-                                {s.activity_name}：{formatMinutes(s.total_minutes)}
+                                <span className="weekly-legend-color" style={{ backgroundColor: activityColor(s.activity_id) }}></span>
+                                {s.activity_name}：{formatSeconds(s.total_seconds)}
                             </li>
                         ))}
                     </ul>
                     <div className="weekly-summary-cards">
                         <div className="weekly-summary-card">
                             <span className="weekly-summary-label">今週の合計</span>
-                            <span className="weekly-summary-value">{formatMinutes(data.total_minutes)}</span>
+                            <span className="weekly-summary-value">{formatSeconds(data.total_seconds)}</span>
                         </div>
                         <div className="weekly-summary-card">
                             <span className="weekly-summary-label">🔥 ストリーク</span>
@@ -134,7 +136,7 @@ export default function WeeklyApp() {
 
             <div className="weekly-card">
                 <p className="weekly-card-title">カテゴリ別詳細（表形式）</p>
-                <WeeklyTable summary={data.summary} formatMinutes={formatMinutes}/>
+                <WeeklyTable summary={data.summary} prevSummary={data.prev_summary} formatSeconds={formatSeconds}/>
             </div>
         {isGoalModalOpen && (
             <WeeklyGoalModal

--- a/app/javascript/react/weekly/WeeklyChart.jsx
+++ b/app/javascript/react/weekly/WeeklyChart.jsx
@@ -1,14 +1,13 @@
 import React from "react";
 import DonutChart from "../dashboard/components/charts/DonutChart";
-
-const COLORS = ["#818cf8", "#fb923c", "#34d399", "#f43f5e", "#900ce9"];
+import { activityColor } from "../activityColor";
 
 export default function WeeklyChart({ summary }) {
     return (
         <DonutChart
             labels={summary.map((s) => s.activity_name)}
-            values={summary.map((s) => s.total_minutes)}
-            colors={summary.map((_, i) => COLORS[i % COLORS.length])}
+            values={summary.map((s) => s.total_seconds)}
+            colors={summary.map((s) => activityColor(s.activity_id))}
             size={240}
         />
     );

--- a/app/javascript/react/weekly/WeeklyTable.jsx
+++ b/app/javascript/react/weekly/WeeklyTable.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 
-export default function WeeklyTable({ summary, formatMinutes }) {
+export default function WeeklyTable({ summary, prevSummary = [], formatSeconds }) {
+    const prevMap = Object.fromEntries(prevSummary.map((s) => [s.activity_id, s.total_seconds]));
+
     return (
         <div style={{ overflowX: "auto", width: "100%" }}>
             <table style={{ width: "max-content", minWidth: "100%" }}>
@@ -14,15 +16,36 @@ export default function WeeklyTable({ summary, formatMinutes }) {
                     </tr>
                 </thead>
                 <tbody>
-                    {summary.map((s) => (
-                        <tr key={s.activity_id}>
-                            <td>{s.activity_name}</td>
-                            <td>{s.count}回</td>
-                            <td>{formatMinutes(s.total_minutes)}</td>
-                            <td>{s.percentage}%</td>
-                            <td>-</td>
-                        </tr>
-                    ))}
+                    {summary.map((s) => {
+                        const prev = prevMap[s.activity_id];
+                        const diff = prev != null ? s.total_seconds - prev : null;
+                        const isNew = prev == null;
+
+                        let diffLabel, diffColor;
+                        if (isNew) {
+                            diffLabel = "NEW";
+                            diffColor = "#6366f1";
+                        } else if (diff > 0) {
+                            diffLabel = `+${formatSeconds(diff)}`;
+                            diffColor = "#22c55e";
+                        } else if (diff < 0) {
+                            diffLabel = `▼${formatSeconds(Math.abs(diff))}`;
+                            diffColor = "#f43f5e";
+                        } else {
+                            diffLabel = "±0";
+                            diffColor = "#94a3b8";
+                        }
+
+                        return (
+                            <tr key={s.activity_id}>
+                                <td>{s.activity_name}</td>
+                                <td>{s.count}回</td>
+                                <td>{formatSeconds(s.total_seconds)}</td>
+                                <td>{s.percentage}%</td>
+                                <td style={{ color: diffColor, fontWeight: 700 }}>{diffLabel}</td>
+                            </tr>
+                        );
+                    })}
                 </tbody>
             </table>
         </div>

--- a/app/services/streak_service.rb
+++ b/app/services/streak_service.rb
@@ -1,6 +1,7 @@
 class StreakService
-  def initialize(user)
-    @user = user
+  def initialize(user, as_of: Date.current)
+    @user  = user
+    @as_of = as_of
   end
 
   def call
@@ -12,10 +13,9 @@ class StreakService
 
     return 0 if recorded_dates.empty?
 
-    # 今日記録があれば今日から、なければ昨日からカウント開始
-    check_date = recorded_dates.include?(Date.current) ? Date.current : Date.current - 1
+    # as_of日に記録があればそこから、なければ前日からカウント開始
+    check_date = recorded_dates.include?(@as_of) ? @as_of : @as_of - 1
 
-    # 昨日も記録がなければストリーク0
     return 0 unless recorded_dates.include?(check_date)
 
     streak = 0

--- a/app/services/weekly_summary_service.rb
+++ b/app/services/weekly_summary_service.rb
@@ -1,5 +1,5 @@
 class WeeklySummaryService
-  MAX_MINUTES = 360
+  MAX_SECONDS = 43200
 
   def initialize(logs)
     @logs = logs.sort_by(&:logged_at)
@@ -8,35 +8,35 @@ class WeeklySummaryService
   def call
     return [] if @logs.empty?
 
-    sums = Hash.new { |h, k| h[k] = { total_minutes: 0, count: 0, activity_name: nil, activity_id: nil } }
+    sums = Hash.new { |h, k| h[k] = { total_seconds: 0, count: 0, activity_name: nil, activity_id: nil } }
 
     @logs.each_with_index do |log, i|
       next_log = @logs[i + 1]
 
-      diff_minutes = if next_log && next_log.logged_at.to_date == log.logged_at.to_date
-                       ((next_log.logged_at - log.logged_at) / 60).floor
-                     elsif log.ended_at
-                       ((log.ended_at - log.logged_at) / 60).floor
+      diff_seconds = if log.ended_at
+                       (log.ended_at - log.logged_at).to_i
+                     elsif next_log && next_log.logged_at.to_date == log.logged_at.to_date
+                       (next_log.logged_at - log.logged_at).to_i
                      else
                        next
                      end
 
-      diff_minutes = [[diff_minutes, 0].max, MAX_MINUTES].min
+      diff_seconds = [[diff_seconds, 0].max, MAX_SECONDS].min
 
       key = log.activity.public_id
-      sums[key][:total_minutes] += diff_minutes
+      sums[key][:total_seconds] += diff_seconds
       sums[key][:count]         += 1
       sums[key][:activity_name] ||= log.activity.name
       sums[key][:activity_id]   ||= log.activity.public_id
       sums[key][:db_id]         ||= log.activity.id
-      sums[key][:icon] ||= log.activity.icon
+      sums[key][:icon]          ||= log.activity.icon
     end
 
-    total = sums.values.sum { |v| v[:total_minutes] }
+    total = sums.values.sum { |v| v[:total_seconds] }
 
     sums.map do |_, v|
-      percentage = total > 0 ? (v[:total_minutes].to_f / total * 100).round : 0
+      percentage = total > 0 ? (v[:total_seconds].to_f / total * 100).round : 0
       v.merge(percentage: percentage)
-    end.sort_by { |h| -h[:total_minutes] }
+    end.sort_by { |h| -h[:total_seconds] }
   end
 end

--- a/test/controllers/api/weekly_controller_test.rb
+++ b/test/controllers/api/weekly_controller_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::WeeklyControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user     = create(:user)
+    @activity = create(:activity, user: @user)
+  end
+
+  # --- 認証 ---
+
+  test "未ログインは401を返す" do
+    get "/api/weekly", headers: { "Accept" => "application/json" }
+    assert_response :unauthorized
+  end
+
+  # --- データなし ---
+
+  test "記録なしでもエラーにならない" do
+    sign_in @user
+    get "/api/weekly"
+    assert_response :success
+    body = response.parsed_body
+    assert_equal [], body["summary"]
+    assert_equal 0,  body["total_seconds"]
+  end
+
+  # --- 今週の集計 ---
+
+  test "今週の記録が集計される" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 1, 10, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.current - 1.hour, ended_at: Time.current)
+      get "/api/weekly"
+      body = response.parsed_body
+      assert_equal 3600, body["total_seconds"]
+      assert_equal 1,  body["summary"].length
+    end
+  end
+
+  # --- 週の移動 ---
+
+  test "weekパラメータで前の週を表示できる" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 8, 10, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.zone.local(2024, 4, 30, 9, 0), ended_at: Time.zone.local(2024, 4, 30, 10, 0))
+      get "/api/weekly", params: { week: "2024-04-29" }
+      body = response.parsed_body
+      assert_equal "2024-04-29", body["week_start"]
+      assert_equal 3600, body["total_seconds"]
+    end
+  end
+
+  test "weekパラメータで未来の週を表示すると記録なしになる" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 1, 10, 0, 0) do
+      get "/api/weekly", params: { week: "2024-05-06" }
+      body = response.parsed_body
+      assert_equal [], body["summary"]
+    end
+  end
+
+  # --- 先週比 ---
+
+  test "レスポンスにprev_summaryが含まれる" do
+    sign_in @user
+    get "/api/weekly"
+    assert response.parsed_body.key?("prev_summary")
+  end
+
+  test "先週の記録がprev_summaryに反映される" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 8, 10, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.zone.local(2024, 4, 30, 9, 0), ended_at: Time.zone.local(2024, 4, 30, 10, 0))
+      get "/api/weekly"
+      prev = response.parsed_body["prev_summary"]
+      assert_equal 1,  prev.length
+      assert_equal 3600, prev.first["total_seconds"]
+    end
+  end
+
+  # --- レスポンス形式 ---
+
+  test "week_start・week_endが返る" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 1, 10, 0, 0) do
+      get "/api/weekly"
+      body = response.parsed_body
+      assert_equal "2024-04-29", body["week_start"]
+      assert_equal "2024-05-05", body["week_end"]
+    end
+  end
+
+  test "streak_daysが返る" do
+    sign_in @user
+    get "/api/weekly"
+    assert response.parsed_body.key?("streak_days")
+  end
+end

--- a/test/services/weekly_summary_service_test.rb
+++ b/test/services/weekly_summary_service_test.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class WeeklySummaryServiceTest < ActiveSupport::TestCase
+  setup do
+    @user     = create(:user)
+    @activity = create(:activity, user: @user)
+  end
+
+  test "記録なしは空配列を返す" do
+    result = WeeklySummaryService.new([]).call
+    assert_equal [], result
+  end
+
+  test "ended_atから時間を計算する" do
+    logs = [
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.zone.local(2024, 5, 1, 9, 0), ended_at: Time.zone.local(2024, 5, 1, 10, 0))
+    ]
+    result = WeeklySummaryService.new(logs).call
+    assert_equal 3600, result.first[:total_seconds]
+  end
+
+  test "ended_atを次のlogged_atより優先する" do
+    activity2 = create(:activity, user: @user)
+    t1 = Time.zone.local(2024, 5, 1, 9, 0)
+    # ended_at = 30分後、次のログ = 50分後 → ended_atを使うべき
+    log1 = create(:record, user: @user, activity: @activity,
+                  logged_at: t1, ended_at: t1 + 30.minutes)
+    log2 = create(:record, user: @user, activity: activity2,
+                  logged_at: t1 + 50.minutes, ended_at: t1 + 60.minutes)
+    result = WeeklySummaryService.new([log1, log2]).call
+    entry = result.find { |s| s[:activity_id] == @activity.public_id }
+    assert_equal 1800, entry[:total_seconds]
+  end
+
+  test "ended_atなし・同日の次ログありは次のlogged_atで計算する" do
+    activity2 = create(:activity, user: @user)
+    t1 = Time.zone.local(2024, 5, 1, 9, 0)
+    log1 = create(:record, user: @user, activity: @activity,
+                  logged_at: t1, ended_at: nil)
+    log2 = create(:record, user: @user, activity: activity2,
+                  logged_at: t1 + 45.minutes, ended_at: t1 + 60.minutes)
+    result = WeeklySummaryService.new([log1, log2]).call
+    entry = result.find { |s| s[:activity_id] == @activity.public_id }
+    assert_equal 2700, entry[:total_seconds]
+  end
+
+  test "ended_atなし・次ログなしはカウントしない" do
+    logs = [
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.zone.local(2024, 5, 1, 9, 0), ended_at: nil)
+    ]
+    result = WeeklySummaryService.new(logs).call
+    assert_equal [], result
+  end
+
+  test "ended_atなし・次ログが翌日はカウントしない" do
+    activity2 = create(:activity, user: @user)
+    log1 = create(:record, user: @user, activity: @activity,
+                  logged_at: Time.zone.local(2024, 5, 1, 23, 0), ended_at: nil)
+    log2 = create(:record, user: @user, activity: activity2,
+                  logged_at: Time.zone.local(2024, 5, 2, 1, 0), ended_at: Time.zone.local(2024, 5, 2, 2, 0))
+    result = WeeklySummaryService.new([log1, log2]).call
+    entry = result.find { |s| s[:activity_id] == @activity.public_id }
+    assert_nil entry
+  end
+
+  test "43200秒(12時間)を超える場合は43200秒に丸める" do
+    logs = [
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.zone.local(2024, 5, 1, 0, 0), ended_at: Time.zone.local(2024, 5, 1, 14, 0))
+    ]
+    result = WeeklySummaryService.new(logs).call
+    assert_equal 43200, result.first[:total_seconds]
+  end
+
+  test "同じ行動の複数ログは合算される" do
+    t = Time.zone.local(2024, 5, 1, 9, 0)
+    create(:record, user: @user, activity: @activity,
+           logged_at: t, ended_at: t + 30.minutes)
+    create(:record, user: @user, activity: @activity,
+           logged_at: t + 2.hours, ended_at: t + 2.hours + 30.minutes)
+    result = WeeklySummaryService.new(@user.records.includes(:activity).to_a).call
+    assert_equal 3600, result.first[:total_seconds]
+    assert_equal 2,    result.first[:count]
+  end
+
+  test "割合が合計に対して正しく計算される" do
+    activity2 = create(:activity, user: @user)
+    t = Time.zone.local(2024, 5, 1, 9, 0)
+    create(:record, user: @user, activity: @activity,
+           logged_at: t, ended_at: t + 60.minutes)
+    create(:record, user: @user, activity: activity2,
+           logged_at: t + 60.minutes, ended_at: t + 120.minutes)
+    result = WeeklySummaryService.new(@user.records.includes(:activity).to_a).call
+    assert_equal 50, result.find { |s| s[:activity_id] == @activity.public_id }[:percentage]
+    assert_equal 50, result.find { |s| s[:activity_id] == activity2.public_id }[:percentage]
+  end
+
+  test "合計時間の多い順にソートされる" do
+    activity2 = create(:activity, user: @user)
+    t = Time.zone.local(2024, 5, 1, 9, 0)
+    create(:record, user: @user, activity: @activity,
+           logged_at: t, ended_at: t + 30.minutes)
+    create(:record, user: @user, activity: activity2,
+           logged_at: t + 30.minutes, ended_at: t + 90.minutes)
+    result = WeeklySummaryService.new(@user.records.includes(:activity).to_a).call
+    assert_equal activity2.public_id, result.first[:activity_id]
+  end
+end


### PR DESCRIPTION
## 概要

- COLORSの重複バグ修正（`#818cf8` が index 0 と 2 に重複していた）
- 行動の色を `activity_id` のハッシュ＋ゴールデンアングルパレットで固定（共通ユーティリティ `activityColor.js` を切り出し、ダッシュボード・週次で共用）
- 先週比を実装（`+増加` 緑 / `▼減少` 赤 / `±0` グレー / `NEW` 紫）
- `WeeklySummaryService` が `ended_at` を最優先で使うよう修正（ダッシュボードと一致）
- 集計を秒単位に統一（`total_minutes` → `total_seconds`、上限 43200秒）
- `DonutChart` のツールチップを秒単位に修正（ダッシュボードでも壊れていたバグ）
- `StreakService` に `as_of` パラメータを追加し、表示中の週末基準でストリークを計算（過去の週に移動すると当時のストリークが表示される）

## 動作確認

- [x] `rails test` 全67件パス
- [x] 週次画面で先週比が色付きで表示されることを確認
- [x] 過去の週に移動するとストリークが変わることを確認
- [x] ダッシュボード・週次で同じ行動が同じ色になることを確認
- [x] グラフのツールチップが正しい時間（秒単位）で表示されることを確認

Closes #206