### PR TITLE
test: 月次カレンダー・日別APIのテストを追加し、total_secondsに修正する（#207）

### DIFF
--- a/app/controllers/api/days_controller.rb
+++ b/app/controllers/api/days_controller.rb
@@ -17,8 +17,8 @@ class Api::DaysController < ApplicationController
 
     render json: {
       date: date.iso8601,
-      total_minutes: summary.sum { |s| s[:total_minutes] },
-      per_category: summary.map { |s| { name: s[:activity_name], minutes: s[:total_minutes], ratio: s[:percentage], icon: s[:icon] } },
+      total_seconds: summary.sum { |s| s[:total_seconds] },
+      per_category: summary.map { |s| { name: s[:activity_name], seconds: s[:total_seconds], ratio: s[:percentage], icon: s[:icon] } },
       logs: logs.map { |log| { activity_name: log.activity.name, logged_at: log.logged_at, ended_at: log.ended_at } },
       share_token: share_link.token
     }

--- a/app/controllers/api/days_controller.rb
+++ b/app/controllers/api/days_controller.rb
@@ -18,7 +18,7 @@ class Api::DaysController < ApplicationController
     render json: {
       date: date.iso8601,
       total_seconds: summary.sum { |s| s[:total_seconds] },
-      per_category: summary.map { |s| { name: s[:activity_name], seconds: s[:total_seconds], ratio: s[:percentage], icon: s[:icon] } },
+      per_category: summary.map { |s| { activity_id: s[:activity_id], name: s[:activity_name], seconds: s[:total_seconds], ratio: s[:percentage], icon: s[:icon] } },
       logs: logs.map { |log| { activity_name: log.activity.name, logged_at: log.logged_at, ended_at: log.ended_at } },
       share_token: share_link.token
     }

--- a/app/controllers/api/monthly_controller.rb
+++ b/app/controllers/api/monthly_controller.rb
@@ -15,7 +15,7 @@ class Api::MonthlyController < ApplicationController
       daily_summaries[date.iso8601] = {
         dominant_category: summary.first[:activity_name],
         dominant_icon: summary.first[:icon],
-        total_minutes: summary.sum { |s| s[:total_minutes]},
+        total_seconds: summary.sum { |s| s[:total_seconds] },
         per_category: summary
       }
     end

--- a/app/controllers/monthly_controller.rb
+++ b/app/controllers/monthly_controller.rb
@@ -14,7 +14,7 @@ class MonthlyController < ApplicationController
       dominant = summary.first
       @daily_summaries[date] = {
         dominant_category: dominant[:activity_name],
-        total_minutes: summary.sum { |s| s[:total_minutes] },
+        total_seconds: summary.sum { |s| s[:total_seconds] },
         per_category: summary
       }
     end

--- a/app/controllers/ogp_controller.rb
+++ b/app/controllers/ogp_controller.rb
@@ -11,12 +11,12 @@ class OgpController < ApplicationController
                      .includes(:activity)
 
     summary = WeeklySummaryService.new(logs).call
-    total_minutes = summary.sum { |s| s[:total_minutes] }
+    total_seconds = summary.sum { |s| s[:total_seconds] }
 
     tmpfile = DailyOgpImageService.new(
       date: date,
       summary: summary,
-      total_minutes: total_minutes
+      total_seconds: total_seconds
     ).call
 
     data = File.binread(tmpfile.path)
@@ -38,13 +38,13 @@ class OgpController < ApplicationController
                      .includes(:activity)
 
     summary = WeeklySummaryService.new(logs).call
-    total_minutes = summary.sum { |s| s[:total_minutes] }
+    total_seconds = summary.sum { |s| s[:total_seconds] }
 
     tmpfile = WeeklyOgpImageService.new(
       week_start: week_start,
       week_end: week_end,
       summary: summary,
-      total_minutes: total_minutes
+      total_seconds: total_seconds
     ).call
 
     data = File.binread(tmpfile.path)

--- a/app/controllers/share_controller.rb
+++ b/app/controllers/share_controller.rb
@@ -12,12 +12,12 @@ class ShareController < ApplicationController
     
     @date = date
     @summary = WeeklySummaryService.new(logs).call
-    @total_minutes = @summary.sum { |s| s[:total_minutes] }
+    @total_seconds = @summary.sum { |s| s[:total_seconds] }
     @top_category = @summary.first
 
     @og_title = "#{@date.strftime('%Y年%-m月%-d日')}の記録 - Study-keeper"
-    desc_parts = @summary.first(3).map { |s| "#{s[:activity_name]} #{s[:total_minutes]}分" }
-    @og_desc = @summary.empty? ? "この日の記録はありません" : "合計#{@total_minutes / 60}時間#{@total_minutes % 60}分 / #{desc_parts.join(' / ')}"
+    desc_parts = @summary.first(3).map { |s| "#{s[:activity_name]} #{s[:total_seconds] / 60}分" }
+    @og_desc = @summary.empty? ? "この日の記録はありません" : "合計#{@total_seconds / 3600}時間#{(@total_seconds % 3600) / 60}分 / #{desc_parts.join(' / ')}"
   end
 
   def weekly
@@ -32,7 +32,7 @@ class ShareController < ApplicationController
                       .includes(:activity)
     
     @summary = WeeklySummaryService.new(logs).call
-    @total_minutes = @summary.sum { |s| s[:total_minutes] }
+    @total_seconds = @summary.sum { |s| s[:total_seconds] }
     @top_categories = @summary.first(3)
 
     user = @share_link.user
@@ -50,8 +50,8 @@ class ShareController < ApplicationController
 
     week_range = "#{@week_start.strftime('%-m/%-d')} - #{@week_end.strftime('%-m/%-d')}"
     @og_title = "#{week_range}の記録 - Study-keeper"
-    desc_parts = @top_categories.map { |s| "#{s[:activity_name]} #{s[:total_minutes] / 60}時間#{s[:total_minutes] % 60}分(#{s[:percentage]}%)" }
-    @og_desc = @summary.empty? ? "この週の記録はありません" : "合計#{@total_minutes / 60}時間#{@total_minutes % 60}分 / #{desc_parts.join(' / ')}"
+    desc_parts = @top_categories.map { |s| "#{s[:activity_name]} #{s[:total_seconds] / 3600}時間#{(s[:total_seconds] % 3600) / 60}分(#{s[:percentage]}%)" }
+    @og_desc = @summary.empty? ? "この週の記録はありません" : "合計#{@total_seconds / 3600}時間#{(@total_seconds % 3600) / 60}分 / #{desc_parts.join(' / ')}"
   end
 
 end

--- a/app/javascript/react/monthly/DailyArchiveModal.jsx
+++ b/app/javascript/react/monthly/DailyArchiveModal.jsx
@@ -1,14 +1,16 @@
 import React, { useEffect, useState } from "react";
 import DonutChart from "../dashboard/components/charts/DonutChart";
-
-const COLORS = ["#818cf8", "#fb923c", "#34d399", "#f43f5e", "#900ce9"];
+import { activityColor } from "../activityColor";
 
 const DAY_NAMES = ["日", "月", "火", "水", "木", "金", "土"];
 
-function formatMinutes(minutes) {
-    const h = Math.floor(minutes / 60);
-    const m = minutes % 60;
-    return h > 0 ? `${h}時間${m}分` : `${m}分`;
+function formatSeconds(seconds) {
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = seconds % 60;
+    if (h > 0) return `${h}時間${m}分`;
+    if (m > 0) return s > 0 ? `${m}分${s}秒` : `${m}分`;
+    return `${s}秒`;
 }
 
 function formatDateHeader(dateStr) {
@@ -28,12 +30,12 @@ function formatTime(isoString) {
 }
 
 function buildDailyShareText(date, data) {
-    if(!data || data.total_minutes === 0) return `${date}の記録はありませんでした\n#StudyKeeper\n`;
-    const total = formatMinutes(data.total_minutes);
+    if(!data || data.total_seconds === 0) return `${date}の記録はありませんでした\n#StudyKeeper\n`;
+    const total = formatSeconds(data.total_seconds);
     const top = data.per_category
-        .filter((c) => c.minutes > 0)
+        .filter((c) => c.seconds > 0)
         .slice(0, 3)
-        .map((c) => `${c.icon} ${c.name} : ${formatMinutes(c.minutes)}`)
+        .map((c) => `${c.icon} ${c.name} : ${formatSeconds(c.seconds)}`)
         .join("\n");
     return `⭐ ${formatDateHeader(date)}の活動記録\n⏱ 合計：${total}\n${top}\n#StudyKeeper\n`;
 }
@@ -58,25 +60,25 @@ export default function DailyArchiveModal({ date, onClose }) {
                 {error && <p>エラーが発生しました</p>}
                 {!data && !error && <p>読み込み中…</p>}
 
-                {data && data.total_minutes === 0 && (
+                {data && data.total_seconds === 0 && (
                     <p className="daily-modal-empty">この日は記録がありません</p>
                 )}
 
-                {data && data.total_minutes > 0 && (
+                {data && data.total_seconds > 0 && (
                     <div className="daily-modal-body">
                         <div className="daily-modal-left">
                             <DonutChart
                                 labels={data.per_category.map((c) => c.name)}
-                                values={data.per_category.map((c) => c.minutes)}
-                                colors={data.per_category.map((_, i) => COLORS[i % COLORS.length])}
+                                values={data.per_category.map((c) => c.seconds)}
+                                colors={data.per_category.map((c) => activityColor(c.activity_id))}
                                 size={180}
                             />
-                            <p className="daily-modal-total">合計：{formatMinutes(data.total_minutes)}</p>
+                            <p className="daily-modal-total">合計：{formatSeconds(data.total_seconds)}</p>
                             <ul className="daily-modal-legend">
-                                {data.per_category.filter((c) => c.minutes > 0).map((c, i) => (
+                                {data.per_category.filter((c) => c.seconds > 0).map((c) => (
                                     <li key={c.name}>
-                                        <span className="daily-modal-color" style={{ backgroundColor: COLORS[i % COLORS.length] }}></span>
-                                        {c.name}：{formatMinutes(c.minutes)}
+                                        <span className="daily-modal-color" style={{ backgroundColor: activityColor(c.activity_id) }}></span>
+                                        {c.name}：{formatSeconds(c.seconds)}
                                     </li>
                                 ))}
                             </ul>
@@ -90,7 +92,7 @@ export default function DailyArchiveModal({ date, onClose }) {
                                 }}
                             >
                                 𝕏 シェアする
-                            </button>    
+                            </button>
                         </div>
 
                         <div className="daily-modal-right">

--- a/app/services/daily_ogp_image_service.rb
+++ b/app/services/daily_ogp_image_service.rb
@@ -8,10 +8,10 @@ class DailyOgpImageService
   BAR_BG_COLOR = "#2d2a5e"
   BAR_MAX_WIDTH = 700
 
-  def initialize(date:, summary:, total_minutes:)
+  def initialize(date:, summary:, total_seconds:)
     @date = date
     @summary = summary
-    @total_minutes = total_minutes
+    @total_seconds = total_seconds
   end
 
   def call
@@ -46,11 +46,11 @@ class DailyOgpImageService
     # 区切り線
     args += ["-fill", ACCENT_COLOR, "-draw", "rectangle 60,175 #{WIDTH - 60},178"]
 
-    if @total_minutes == 0
+    if @total_seconds == 0
       args += ["-fill", "#aaaacc", "-pointsize", "40", "-draw", "text 60,280 'この日の記録はありません'"]
     else
-      h = @total_minutes / 60
-      m = @total_minutes % 60
+      h = @total_seconds / 3600
+      m = (@total_seconds % 3600) / 60
       total_text = h > 0 ? "#{h}時間#{m}分" : "#{m}分"
 
       args += ["-fill", "#aaaacc", "-pointsize", "30", "-draw", "text 60,240 '合計時間'"]
@@ -60,7 +60,7 @@ class DailyOgpImageService
         y_base = 400 + i * 70
         bar_width = (s[:percentage].to_f / 100 * BAR_MAX_WIDTH).round.clamp(4, BAR_MAX_WIDTH)
         name = s[:activity_name].to_s.slice(0, 10)
-        time_text = "#{s[:total_minutes] / 60}時間#{s[:total_minutes] % 60}分 (#{s[:percentage]}%)"
+        time_text = "#{s[:total_seconds] / 3600}時間#{(s[:total_seconds] % 3600) / 60}分 (#{s[:percentage]}%)"
 
         args += ["-fill", BAR_BG_COLOR, "-draw", "rectangle 60,#{y_base} #{60 + BAR_MAX_WIDTH},#{y_base + 28}"]
         args += ["-fill", BAR_COLOR,    "-draw", "rectangle 60,#{y_base} #{60 + bar_width},#{y_base + 28}"]

--- a/app/services/weekly_ogp_image_service.rb
+++ b/app/services/weekly_ogp_image_service.rb
@@ -8,11 +8,11 @@ class WeeklyOgpImageService
   BAR_BG_COLOR = "#2d2a5e"
   BAR_MAX_WIDTH = 700
 
-  def initialize(week_start:, week_end:, summary:, total_minutes:)
+  def initialize(week_start:, week_end:, summary:, total_seconds:)
     @week_start = week_start
     @week_end = week_end
     @summary = summary
-    @total_minutes = total_minutes
+    @total_seconds = total_seconds
   end
 
   def call
@@ -49,11 +49,11 @@ class WeeklyOgpImageService
     # 区切り線
     args += ["-fill", ACCENT_COLOR, "-draw", "rectangle 60,165 #{WIDTH - 60},168"]
 
-    if @total_minutes == 0
+    if @total_seconds == 0
       args += ["-fill", "#aaaacc", "-pointsize", "40", "-draw", "text 60,280 'この週の記録はありません'"]
     else
-      h = @total_minutes / 60
-      m = @total_minutes % 60
+      h = @total_seconds / 3600
+      m = (@total_seconds % 3600) / 60
       total_text = h > 0 ? "#{h}時間#{m}分" : "#{m}分"
 
       args += ["-fill", "#aaaacc", "-pointsize", "30", "-draw", "text 60,230 '合計時間'"]
@@ -63,7 +63,7 @@ class WeeklyOgpImageService
         y_base = 390 + i * 70
         bar_width = (s[:percentage].to_f / 100 * BAR_MAX_WIDTH).round.clamp(4, BAR_MAX_WIDTH)
         name = s[:activity_name].to_s.slice(0, 10)
-        time_text = "#{s[:total_minutes] / 60}時間#{s[:total_minutes] % 60}分 (#{s[:percentage]}%)"
+        time_text = "#{s[:total_seconds] / 3600}時間#{(s[:total_seconds] % 3600) / 60}分 (#{s[:percentage]}%)"
 
         args += ["-fill", BAR_BG_COLOR, "-draw", "rectangle 60,#{y_base} #{60 + BAR_MAX_WIDTH},#{y_base + 28}"]
         args += ["-fill", BAR_COLOR,    "-draw", "rectangle 60,#{y_base} #{60 + bar_width},#{y_base + 28}"]

--- a/app/views/share/daily.html.erb
+++ b/app/views/share/daily.html.erb
@@ -20,7 +20,7 @@
     <% else %>
       <div class="share-total">
         <span class="share-total-label">合計時間</span>
-        <span class="share-total-value"><%= @total_minutes / 60 %>時間 <%= @total_minutes % 60 %>分</span>
+        <span class="share-total-value"><%= @total_seconds / 3600 %>時間 <%= (@total_seconds % 3600) / 60 %>分</span>
       </div>
 
       <div class="share-categories">
@@ -33,7 +33,7 @@
             <div class="share-category-bar-wrap">
               <div class="share-category-bar" style="width: <%= s[:percentage] %>%"></div>
             </div>
-            <span class="share-category-time"><%= s[:total_minutes] %>分（<%= s[:percentage] %>%）</span>
+            <span class="share-category-time"><%= s[:total_seconds] / 60 %>分（<%= s[:percentage] %>%）</span>
           </div>
         <% end %>
       </div>

--- a/app/views/share/weekly.html.erb
+++ b/app/views/share/weekly.html.erb
@@ -20,7 +20,7 @@
     <% else %>
       <div class="share-total">
         <span class="share-total-label">合計時間</span>
-        <span class="share-total-value"><%= @total_minutes / 60 %>時間 <%= @total_minutes % 60 %>分</span>
+        <span class="share-total-value"><%= @total_seconds / 3600 %>時間 <%= (@total_seconds % 3600) / 60 %>分</span>
       </div>
 
       <div class="share-categories">
@@ -33,7 +33,7 @@
             <div class="share-category-bar-wrap">
               <div class="share-category-bar" style="width: <%= s[:percentage] %>%"></div>
             </div>
-            <span class="share-category-time"><%= s[:total_minutes] %>分（<%= s[:percentage] %>%）</span>
+            <span class="share-category-time"><%= s[:total_seconds] / 60 %>分（<%= s[:percentage] %>%）</span>
           </div>
         <% end %>
       </div>

--- a/test/controllers/api/days_controller_test.rb
+++ b/test/controllers/api/days_controller_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::DaysControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user     = create(:user)
+    @activity = create(:activity, user: @user)
+  end
+
+  # --- 認証 ---
+
+  test "未ログインは401を返す" do
+    get "/api/days/2024-05-01", headers: { "Accept" => "application/json" }
+    assert_response :unauthorized
+  end
+
+  # --- 正常系 ---
+
+  test "指定日の記録が返る" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 10, 10, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.current - 1.hour, ended_at: Time.current)
+      get "/api/days/2024-05-10"
+      assert_response :success
+      body = response.parsed_body
+      assert_equal "2024-05-10", body["date"]
+      assert_equal 3600, body["total_seconds"]
+      assert_equal 1, body["per_category"].length
+      assert_equal 1, body["logs"].length
+    end
+  end
+
+  test "記録なしの日でもエラーにならない" do
+    sign_in @user
+    get "/api/days/2024-05-01"
+    assert_response :success
+    body = response.parsed_body
+    assert_equal 0,  body["total_seconds"]
+    assert_equal [], body["per_category"]
+    assert_equal [], body["logs"]
+  end
+
+  test "per_categoryにsecondsとratioが含まれる" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 10, 10, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.current - 1.hour, ended_at: Time.current)
+      get "/api/days/2024-05-10"
+      cat = response.parsed_body["per_category"].first
+      assert cat.key?("seconds")
+      assert cat.key?("ratio")
+    end
+  end
+
+  # --- 異常系 ---
+
+  test "不正な日付は400を返す" do
+    sign_in @user
+    get "/api/days/invalid-date"
+    assert_response :bad_request
+  end
+end

--- a/test/controllers/api/monthly_controller_test.rb
+++ b/test/controllers/api/monthly_controller_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::MonthlyControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user     = create(:user)
+    @activity = create(:activity, user: @user)
+  end
+
+  # --- 認証 ---
+
+  test "未ログインは401を返す" do
+    get "/api/monthly", headers: { "Accept" => "application/json" }
+    assert_response :unauthorized
+  end
+
+  # --- データなし ---
+
+  test "記録なしでもエラーにならない" do
+    sign_in @user
+    get "/api/monthly"
+    assert_response :success
+    body = response.parsed_body
+    assert_equal({}, body["daily_summaries"])
+  end
+
+  # --- 月の範囲 ---
+
+  test "当月の開始・終了日が返る" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 15, 10, 0, 0) do
+      get "/api/monthly"
+      body = response.parsed_body
+      assert_equal "2024-05-01", body["month_start"]
+      assert_equal "2024-05-31", body["month_end"]
+    end
+  end
+
+  test "monthパラメータで前月を表示できる" do
+    sign_in @user
+    get "/api/monthly", params: { month: "2024-04" }
+    body = response.parsed_body
+    assert_equal "2024-04-01", body["month_start"]
+    assert_equal "2024-04-30", body["month_end"]
+  end
+
+  # --- 日別代表カテゴリ ---
+
+  test "記録のある日にdaily_summariesが作られる" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 10, 10, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.current - 1.hour, ended_at: Time.current)
+      get "/api/monthly"
+      body = response.parsed_body
+      assert body["daily_summaries"].key?("2024-05-10")
+    end
+  end
+
+  test "dominant_categoryは最も時間の多い行動名になる" do
+    sign_in @user
+    activity2 = create(:activity, user: @user)
+    travel_to Time.zone.local(2024, 5, 10, 12, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.current - 30.minutes, ended_at: Time.current)
+      create(:record, user: @user, activity: activity2,
+             logged_at: Time.current - 2.hours, ended_at: Time.current - 30.minutes)
+      get "/api/monthly"
+      dominant = response.parsed_body["daily_summaries"]["2024-05-10"]["dominant_category"]
+      assert_equal activity2.name, dominant
+    end
+  end
+
+  test "記録のない日はdaily_summariesに含まれない" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 10, 10, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.current - 1.hour, ended_at: Time.current)
+      get "/api/monthly"
+      body = response.parsed_body
+      assert_not body["daily_summaries"].key?("2024-05-09")
+    end
+  end
+
+  test "先月の記録は当月のdaily_summariesに含まれない" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 10, 10, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.zone.local(2024, 4, 30, 9, 0), ended_at: Time.zone.local(2024, 4, 30, 10, 0))
+      get "/api/monthly"
+      assert_equal({}, response.parsed_body["daily_summaries"])
+    end
+  end
+
+  test "daily_summariesにtotal_secondsが含まれる" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 10, 10, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.current - 1.hour, ended_at: Time.current)
+      get "/api/monthly"
+      day = response.parsed_body["daily_summaries"]["2024-05-10"]
+      assert day.key?("total_seconds")
+      assert_equal 3600, day["total_seconds"]
+    end
+  end
+end


### PR DESCRIPTION
## 概要

- `MonthlyController`・`DaysController` の `total_minutes` → `total_seconds` バグを修正（前PRでの修正漏れ）
- `GET /api/monthly` テスト追加
- `GET /api/days/:date` テスト追加

## テストケース

**monthly_controller_test (8件)**
- 未ログインは401
- 記録なしでもエラーにならない
- 当月の開始・終了日が返る
- monthパラメータで前月を表示できる
- 記録のある日にdaily_summariesが作られる
- dominant_categoryは最も時間の多い行動名になる
- 記録のない日・先月の記録はdaily_summariesに含まれない
- daily_summariesにtotal_secondsが含まれる

**days_controller_test (6件)**
- 未ログインは401
- 指定日の記録が返る
- 記録なしの日でもエラーにならない
- per_categoryにsecondsとratioが含まれる
- 不正な日付は400を返す

## 動作確認

- [x] `rails test` 全81件パス

Closes #207