### PR TITLE
fix: 日別アーカイブモーダルの改善とテスト追加（#208）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -621,35 +621,58 @@ html, body {
   list-style: none;
   padding: 0;
   margin: 0;
+  max-height: 340px;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 6px;
-
-  li {
-    font-size: 0.8rem;
-  }
+  gap: 2px;
 }
 
 .daily-modal-log-item {
   display: flex;
-  flex-direction: column;
-  padding: 8px 0;
-  border-bottom: 1px solid #f0f0f0;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  transition: background 0.15s;
 
-  &:last-child {
-    border-bottom: none;
+  &:hover {
+    background: rgba(238, 242, 255, 0.6);
   }
 }
 
+.daily-modal-log-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
 .daily-modal-log-time {
-  color: #888;
-  font-size: 0.75rem;
+  color: #94a3b8;
+  font-size: 0.68rem;
+  font-family: monospace;
+  flex-shrink: 0;
+}
+
+.daily-modal-log-icon {
+  font-size: 0.9rem;
   flex-shrink: 0;
 }
 
 .daily-modal-log-name {
-  font-size: 0.875rem;
-  word-break: break-all;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #334155;
+  flex: 1;
+  min-width: 0;
+}
+
+.daily-modal-log-duration {
+  font-size: 0.65rem;
+  font-family: monospace;
+  font-weight: 700;
+  flex-shrink: 0;
 }
 
 .monthly-day-dot {

--- a/app/controllers/api/days_controller.rb
+++ b/app/controllers/api/days_controller.rb
@@ -19,7 +19,7 @@ class Api::DaysController < ApplicationController
       date: date.iso8601,
       total_seconds: summary.sum { |s| s[:total_seconds] },
       per_category: summary.map { |s| { activity_id: s[:activity_id], name: s[:activity_name], seconds: s[:total_seconds], ratio: s[:percentage], icon: s[:icon] } },
-      logs: logs.map { |log| { activity_name: log.activity.name, logged_at: log.logged_at, ended_at: log.ended_at } },
+      logs: logs.order(:logged_at).map { |log| { activity_id: log.activity.public_id, activity_name: log.activity.name, icon: log.activity.icon, logged_at: log.logged_at, ended_at: log.ended_at } },
       share_token: share_link.token
     }
   rescue ArgumentError

--- a/app/javascript/react/monthly/DailyArchiveModal.jsx
+++ b/app/javascript/react/monthly/DailyArchiveModal.jsx
@@ -98,12 +98,23 @@ export default function DailyArchiveModal({ date, onClose }) {
                         <div className="daily-modal-right">
                             <p className="daily-modal-section-title">今日の行動履歴</p>
                             <ul className="daily-modal-logs">
-                                {data.logs.map((log, i) => (
-                                    <li key={i} className="daily-modal-log-item">
-                                        <span className="daily-modal-log-time">{formatTime(log.logged_at)}</span>
-                                        <span className="daily-modal-log-name">{log.activity_name}</span>
-                                    </li>
-                                ))}
+                                {data.logs.map((log, i) => {
+                                    const color = activityColor(log.activity_id);
+                                    const duration = log.ended_at
+                                        ? formatSeconds(Math.max(0, Math.floor((new Date(log.ended_at) - new Date(log.logged_at)) / 1000)))
+                                        : null;
+                                    return (
+                                        <li key={i} className="daily-modal-log-item">
+                                            <span className="daily-modal-log-dot" style={{ backgroundColor: color }} />
+                                            <span className="daily-modal-log-time">{formatTime(log.logged_at)}</span>
+                                            <span className="daily-modal-log-icon">{log.icon}</span>
+                                            <span className="daily-modal-log-name">{log.activity_name}</span>
+                                            {duration && (
+                                                <span className="daily-modal-log-duration" style={{ color }}>{duration}</span>
+                                            )}
+                                        </li>
+                                    );
+                                })}
                             </ul>
                         </div>
                     </div>

--- a/test/controllers/api/days_controller_test.rb
+++ b/test/controllers/api/days_controller_test.rb
@@ -54,6 +54,75 @@ class Api::DaysControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # --- 集計ロジック詳細 ---
+
+  test "複数行動の合計秒数が正しく集計される" do
+    sign_in @user
+    activity2 = create(:activity, user: @user)
+    travel_to Time.zone.local(2024, 5, 10, 12, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.current - 2.hours, ended_at: Time.current - 1.hour)
+      create(:record, user: @user, activity: activity2,
+             logged_at: Time.current - 1.hour, ended_at: Time.current)
+      get "/api/days/2024-05-10"
+      body = response.parsed_body
+      assert_equal 7200, body["total_seconds"]
+      assert_equal 2, body["per_category"].length
+    end
+  end
+
+  test "per_categoryは秒数の多い順に並ぶ" do
+    sign_in @user
+    activity2 = create(:activity, user: @user)
+    travel_to Time.zone.local(2024, 5, 10, 12, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.current - 3.hours, ended_at: Time.current - 2.hours)
+      create(:record, user: @user, activity: activity2,
+             logged_at: Time.current - 2.hours, ended_at: Time.current)
+      get "/api/days/2024-05-10"
+      cats = response.parsed_body["per_category"]
+      assert_equal activity2.name, cats.first["name"]
+    end
+  end
+
+  test "per_categoryの割合が合計に対して正しく計算される" do
+    sign_in @user
+    activity2 = create(:activity, user: @user)
+    travel_to Time.zone.local(2024, 5, 10, 12, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.current - 2.hours, ended_at: Time.current - 1.hour)
+      create(:record, user: @user, activity: activity2,
+             logged_at: Time.current - 1.hour, ended_at: Time.current)
+      get "/api/days/2024-05-10"
+      cats = response.parsed_body["per_category"]
+      assert_equal 50, cats.first["ratio"]
+      assert_equal 50, cats.last["ratio"]
+    end
+  end
+
+  test "他の日の記録は集計に含まれない" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 10, 10, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.zone.local(2024, 5, 9, 9, 0), ended_at: Time.zone.local(2024, 5, 9, 10, 0))
+      get "/api/days/2024-05-10"
+      body = response.parsed_body
+      assert_equal 0, body["total_seconds"]
+    end
+  end
+
+  test "per_categoryにactivity_idが含まれる" do
+    sign_in @user
+    travel_to Time.zone.local(2024, 5, 10, 10, 0, 0) do
+      create(:record, user: @user, activity: @activity,
+             logged_at: Time.current - 1.hour, ended_at: Time.current)
+      get "/api/days/2024-05-10"
+      cat = response.parsed_body["per_category"].first
+      assert cat.key?("activity_id")
+      assert_equal @activity.public_id.to_s, cat["activity_id"]
+    end
+  end
+
   # --- 異常系 ---
 
   test "不正な日付は400を返す" do


### PR DESCRIPTION
## 概要

- `DailyArchiveModal` の行動履歴ログにカラードット・時刻・アイコン・継続時間を追加
- 2カラムグリッドを廃止し、最大高さ340pxのスクロール可能な1カラムリストに変更（エントリが多くても読みやすく）
- `days_controller` のログレスポンスに `ended_at` を追加
- 日別アーカイブAPIのテストを追加（#208）

## 動作確認

- [ ] `rails test test/controllers/api/days_controller_test.rb` が全件グリーン
- [ ] 日別アーカイブモーダルを開いてログ一覧がスクロール可能なリストで表示される
- [ ] 各ログ行にカラードット・時刻・アイコン・継続時間が表示される