### PR TITLE
test: 設定画面のAPI・カテゴリ管理テストを追加する（#209）

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,4 +1,6 @@
 class Activity < ApplicationRecord
   belongs_to :user, optional: true
   has_many :records, dependent: :destroy
+
+  validates :name, presence: true
 end

--- a/test/controllers/api/activities_controller_test.rb
+++ b/test/controllers/api/activities_controller_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::ActivitiesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user     = create(:user)
+    @activity = create(:activity, user: @user, name: "数学", active: true)
+  end
+
+  # --- 認証 ---
+
+  test "未ログインは401を返す (index)" do
+    get "/api/activities", headers: { "Accept" => "application/json" }
+    assert_response :unauthorized
+  end
+
+  test "未ログインは401を返す (create)" do
+    post "/api/activities", params: { activity: { name: "英語", icon: "📝" } }, as: :json
+    assert_response :unauthorized
+  end
+
+  # --- index ---
+
+  test "アクティブなカテゴリ一覧が返る" do
+    sign_in @user
+    get "/api/activities"
+    assert_response :success
+    body = response.parsed_body
+    assert_equal 1, body.length
+    assert_equal "数学", body.first["name"]
+  end
+
+  test "非アクティブなカテゴリはindexに含まれない" do
+    sign_in @user
+    create(:activity, user: @user, name: "理科", active: false)
+    get "/api/activities"
+    names = response.parsed_body.map { |a| a["name"] }
+    assert_not_includes names, "理科"
+  end
+
+  test "他ユーザーのカテゴリは含まれない" do
+    other = create(:user)
+    create(:activity, user: other, name: "他人の科目")
+    sign_in @user
+    get "/api/activities"
+    names = response.parsed_body.map { |a| a["name"] }
+    assert_not_includes names, "他人の科目"
+  end
+
+  # --- create ---
+
+  test "カテゴリを新規作成できる" do
+    sign_in @user
+    assert_difference "Activity.count", 1 do
+      post "/api/activities", params: { activity: { name: "英語", icon: "📝" } }, as: :json
+    end
+    assert_response :created
+    body = response.parsed_body
+    assert_equal "英語", body["name"]
+    assert_equal "📝",  body["icon"]
+  end
+
+  test "nameなしはエラーになる" do
+    sign_in @user
+    post "/api/activities", params: { activity: { name: "", icon: "📝" } }, as: :json
+    assert_response :unprocessable_entity
+    assert response.parsed_body.key?("errors")
+  end
+
+  # --- update (active ON/OFF) ---
+
+  test "カテゴリをOFFにできる" do
+    sign_in @user
+    patch "/api/activities/#{@activity.id}", params: { active: false }, as: :json
+    assert_response :success
+    assert_equal false, @activity.reload.active
+  end
+
+  test "カテゴリをONに戻せる" do
+    sign_in @user
+    @activity.update!(active: false)
+    patch "/api/activities/#{@activity.id}", params: { active: true }, as: :json
+    assert_response :success
+    assert_equal true, @activity.reload.active
+  end
+
+  test "他ユーザーのカテゴリは更新できない" do
+    other     = create(:user)
+    other_act = create(:activity, user: other)
+    sign_in @user
+    patch "/api/activities/#{other_act.id}", params: { active: false }, as: :json
+    assert_response :not_found
+  end
+
+  # --- destroy ---
+
+  test "カテゴリを削除できる" do
+    sign_in @user
+    assert_difference "Activity.count", -1 do
+      delete "/api/activities/#{@activity.id}", as: :json
+    end
+    assert_response :success
+  end
+
+  test "他ユーザーのカテゴリは削除できない" do
+    other     = create(:user)
+    other_act = create(:activity, user: other)
+    sign_in @user
+    delete "/api/activities/#{other_act.id}", as: :json
+    assert_response :not_found
+  end
+end

--- a/test/controllers/api/settings_controller_test.rb
+++ b/test/controllers/api/settings_controller_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::SettingsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+  end
+
+  # --- 認証 ---
+
+  test "未ログインは401を返す (show)" do
+    get "/api/settings", headers: { "Accept" => "application/json" }
+    assert_response :unauthorized
+  end
+
+  test "未ログインは401を返す (update)" do
+    patch "/api/settings", params: { default_page: "weekly" }, as: :json
+    assert_response :unauthorized
+  end
+
+  # --- show ---
+
+  test "設定情報が返る" do
+    sign_in @user
+    get "/api/settings"
+    assert_response :success
+    body = response.parsed_body
+    assert body.key?("name")
+    assert body.key?("email")
+    assert body.key?("categories")
+    assert body.key?("default_page")
+  end
+
+  test "カテゴリ一覧が含まれる" do
+    sign_in @user
+    create(:activity, user: @user, name: "数学", active: true)
+    create(:activity, user: @user, name: "英語", active: false)
+    get "/api/settings"
+    body = response.parsed_body
+    assert_equal 2, body["categories"].length
+    cat_names = body["categories"].map { |c| c["name"] }
+    assert_includes cat_names, "数学"
+    assert_includes cat_names, "英語"
+  end
+
+  test "カテゴリにactive属性が含まれる" do
+    sign_in @user
+    create(:activity, user: @user, active: true)
+    get "/api/settings"
+    cat = response.parsed_body["categories"].first
+    assert cat.key?("active")
+    assert_equal true, cat["active"]
+  end
+
+  test "他ユーザーのカテゴリは含まれない" do
+    other = create(:user)
+    create(:activity, user: other, name: "他人の活動")
+    sign_in @user
+    get "/api/settings"
+    cat_names = response.parsed_body["categories"].map { |c| c["name"] }
+    assert_not_includes cat_names, "他人の活動"
+  end
+
+  test "default_pageのデフォルトはdailyである" do
+    sign_in @user
+    get "/api/settings"
+    assert_equal "daily", response.parsed_body["default_page"]
+  end
+
+  # --- update ---
+
+  test "default_pageを変更できる" do
+    sign_in @user
+    patch "/api/settings", params: { default_page: "weekly" }, as: :json
+    assert_response :success
+    assert_equal "weekly", response.parsed_body["default_page"]
+    assert_equal "weekly", @user.reload.default_page
+  end
+
+  test "default_pageの変更がDBに永続化される" do
+    sign_in @user
+    patch "/api/settings", params: { default_page: "monthly" }, as: :json
+    @user.reload
+    assert_equal "monthly", @user.default_page
+  end
+end


### PR DESCRIPTION
## 概要

- `Api::SettingsController#show` — 設定情報・カテゴリ一覧・デフォルトページの取得をテスト
- `Api::SettingsController#update` — `default_page` の変更とDB永続化をテスト
- `Api::ActivitiesController` — index/create/update(active ON/OFF)/destroy の正常系・異常系・認証チェックをテスト
- `Activity` モデルに `validates :name, presence: true` を追加（バリデーションの実装がなかったため）

## 動作確認

- [ ] `rails test test/controllers/api/settings_controller_test.rb test/controllers/api/activities_controller_test.rb` が全件グリーン（21件）