### PR TITLE
test: ソーシャルログイン（Google/GitHub/X）のテストを追加する（#212）

### DIFF
--- a/test/integration/omniauth_callbacks_test.rb
+++ b/test/integration/omniauth_callbacks_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class OmniauthCallbacksTest < ActionDispatch::IntegrationTest
+  setup do
+    OmniAuth.config.test_mode = true
+  end
+
+  teardown do
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:google_oauth2] = nil
+    OmniAuth.config.mock_auth[:github]        = nil
+    OmniAuth.config.mock_auth[:twitter]       = nil
+  end
+
+  # --- Google ---
+
+  test "Google OAuth初回ログインでユーザーが作成されログインする" do
+    OmniAuth.config.mock_auth[:google_oauth2] = build_auth_hash("google_oauth2", "g001", "google@example.com")
+    assert_difference "User.count", 1 do
+      get "/users/auth/google_oauth2/callback"
+    end
+    assert_response :redirect
+  end
+
+  test "Google OAuth 2回目ログインで既存ユーザーがログインする" do
+    user = create(:user, provider: "google_oauth2", uid: "g001")
+    OmniAuth.config.mock_auth[:google_oauth2] = build_auth_hash("google_oauth2", "g001", user.email)
+    assert_no_difference "User.count" do
+      get "/users/auth/google_oauth2/callback"
+    end
+    assert_response :redirect
+  end
+
+  # --- GitHub ---
+
+  test "GitHub OAuth初回ログインでユーザーが作成される" do
+    OmniAuth.config.mock_auth[:github] = build_auth_hash("github", "gh001", "github@example.com")
+    assert_difference "User.count", 1 do
+      get "/users/auth/github/callback"
+    end
+    assert_response :redirect
+  end
+
+  test "GitHubでemailなしの場合に仮メールでユーザーが作成される" do
+    OmniAuth.config.mock_auth[:github] = build_auth_hash("github", "gh002", nil, "ghuser")
+    assert_difference "User.count", 1 do
+      get "/users/auth/github/callback"
+    end
+    created = User.find_by(provider: "github", uid: "gh002")
+    assert_match /github_gh002@example\.invalid/, created.email
+  end
+
+  # --- X (Twitter) ---
+
+  test "X OAuth初回ログインでユーザーが作成される" do
+    OmniAuth.config.mock_auth[:twitter] = build_auth_hash("twitter", "tw001", nil, "xuser")
+    assert_difference "User.count", 1 do
+      get "/users/auth/twitter/callback"
+    end
+    assert_response :redirect
+  end
+
+  # --- 認可拒否 ---
+
+  test "認可拒否時にログインページにリダイレクトされる" do
+    OmniAuth.config.mock_auth[:github] = :access_denied
+    get "/users/auth/github/callback"
+    # OmniAuthはまず /users/auth/failure へリダイレクトし、
+    # そこから failure アクションが new_user_session_path へリダイレクトする
+    follow_redirect! while response.redirect?
+    assert_equal new_user_session_path, path
+  end
+
+  private
+
+  def build_auth_hash(provider, uid, email, nickname = "testuser")
+    OmniAuth::AuthHash.new(
+      provider: provider,
+      uid:      uid,
+      info:     { email: email, name: nickname, nickname: nickname }
+    )
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -64,6 +64,31 @@ class UserTest < ActiveSupport::TestCase
     assert_difference('User.count', 1) { User.from_omniauth(auth) }
   end
 
+  test 'from_omniauth generates fallback email when provider has no email' do
+    auth = mock_auth('twitter', 'tw999', nil, 'twitteruser')
+    user = User.from_omniauth(auth)
+    assert user.persisted?
+    assert_match /twitter_tw999@example\.invalid/, user.email
+  end
+
+  test 'from_omniauth uses nickname as name when name is blank' do
+    auth = OpenStruct.new(
+      provider: 'github',
+      uid: 'gh001',
+      info: OpenStruct.new(email: nil, name: nil, nickname: 'octocat')
+    )
+    user = User.from_omniauth(auth)
+    assert_equal 'octocat', user.name
+  end
+
+  test 'from_omniauth truncates name to 20 characters' do
+    long_name = 'a' * 30
+    auth = mock_auth('google_oauth2', 'g001', 'long@example.com', long_name)
+    user = User.from_omniauth(auth)
+    assert user.persisted?
+    assert user.name.length <= 20
+  end
+
   private
 
   def mock_auth(provider, uid, email, name = 'Test User')


### PR DESCRIPTION
## 概要

- `User.from_omniauth` のユニットテストを拡充（仮メール生成・name切り詰め・nickname使用）
- OmniAuthコールバックコントローラーのintegrationテストを追加
  - Google/GitHub/X の初回ログイン（ユーザー作成）
  - 2回目ログイン（既存ユーザー再ログイン）
  - emailなし（GitHub/X）での仮メール生成
  - 認可拒否時のログインページリダイレクト

## 動作確認

- [ ] `rails test test/models/user_test.rb test/integration/omniauth_callbacks_test.rb` が全件グリーン（20件）