### PR TITLE
fix: メーラーのホストを独自ドメインに変更する（#214）

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,7 +96,7 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-  config.action_mailer.default_url_options = { host: 'study-keeper.onrender.com', protocol: 'https' }
+  config.action_mailer.default_url_options = { host: 'study-keeper.com', protocol: 'https' }
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true


### PR DESCRIPTION
## 概要

- `config/environments/production.rb` のメーラーホストを `study-keeper.onrender.com` → `study-keeper.com` に変更
- パスワードリセットメール等の本文URLが独自ドメインで生成されるようになる

## その他（手動設定済み）

- Render Custom Domains に `study-keeper.com` を追加済み
- DNS CNAMEレコード設定済み
- SSL証明書自動発行済み
- `force_ssl = true` は設定済み、OGPタグも絶対URL生成済みで対応不要
