### PR TITLE
feat: ダッシュボードにカテゴリ追加機能を実装する

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -453,6 +453,7 @@ html, body {
   max-width: 90vw;
   box-sizing: border-box;
   position: relative;
+  overflow: visible;
 }
 
 .modal-title {

--- a/app/javascript/react/dashboard/DashboardApp.jsx
+++ b/app/javascript/react/dashboard/DashboardApp.jsx
@@ -105,6 +105,7 @@ export default function DashboardApp() {
             activities={activities}
             onSubmit={handleSubmit}
             isSubmitting={isSubmitting}
+            onActivityAdded={() => loadAll()}
           />
         </div>
         <div className="dashboard-right-col">

--- a/app/javascript/react/dashboard/components/LogForm.jsx
+++ b/app/javascript/react/dashboard/components/LogForm.jsx
@@ -1,10 +1,12 @@
 import React, { useState } from "react";
+import CategoryFormModal from "../../settings/CategoryFormModal";
 
-export default function LogForm({ activities, onSubmit, isSubmitting }) {
+export default function LogForm({ activities, onSubmit, isSubmitting, onActivityAdded }) {
   const [selectedId, setSelectedId] = useState(null);
   const [memo, setMemo] = useState("");
   const [hoveredId, setHoveredId] = useState(null);
   const [btnHover, setBtnHover] = useState(false);
+  const [showAddModal, setShowAddModal] = useState(false);
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -88,6 +90,32 @@ export default function LogForm({ activities, onSubmit, isSubmitting }) {
               </button>
             );
           })}
+
+          {/* カテゴリ追加ボタン */}
+          <button
+            type="button"
+            onClick={() => setShowAddModal(true)}
+            onMouseEnter={() => setHoveredId("__add__")}
+            onMouseLeave={() => setHoveredId(null)}
+            style={{
+              border: "2px dashed",
+              borderColor: hoveredId === "__add__" ? "#818cf8" : "#cbd5e1",
+              borderRadius: 16,
+              padding: "14px 8px",
+              cursor: "pointer",
+              background: hoveredId === "__add__" ? "rgba(238,242,255,0.9)" : "rgba(255,255,255,0.4)",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: 6,
+              transition: "all 0.2s",
+              transform: hoveredId === "__add__" ? "translateY(-4px)" : "none",
+              boxShadow: hoveredId === "__add__" ? "0 8px 20px rgba(99,102,241,0.2)" : "none",
+            }}
+          >
+            <span style={{ fontSize: 26, color: hoveredId === "__add__" ? "#818cf8" : "#94a3b8" }}>＋</span>
+            <span style={{ color: hoveredId === "__add__" ? "#4f46e5" : "#94a3b8", fontSize: 11, fontWeight: 700 }}>追加</span>
+          </button>
         </div>
 
         {/* メモ欄 */}
@@ -142,6 +170,16 @@ export default function LogForm({ activities, onSubmit, isSubmitting }) {
           {isSubmitting ? "記録中..." : "記録する"}
         </button>
       </form>
+
+      {showAddModal && (
+        <CategoryFormModal
+          onClose={() => setShowAddModal(false)}
+          onAdd={(newActivity) => {
+            onActivityAdded?.(newActivity);
+            setShowAddModal(false);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/app/javascript/react/settings/CategoryFormModal.jsx
+++ b/app/javascript/react/settings/CategoryFormModal.jsx
@@ -43,7 +43,7 @@ export default function CategoryFormModal({ onClose, onAdd }) {
                 <h2 className="modal-title">カテゴリを追加</h2>
                 {error && <p className="modal-error">{error}</p>}
                 <form onSubmit={handleSubmit}>
-                    <div className="modal-field">
+                    <div className="modal-field" style={{ position: "relative" }}>
                         <label>アイコン(絵文字)</label>
                         <button
                             type="button"
@@ -53,15 +53,23 @@ export default function CategoryFormModal({ onClose, onAdd }) {
                             {icon || "＋ 選択"}
                         </button>
                         {showPicker && (
-                            <Picker
-                                data={data}
-                                locale="ja"
-                                onEmojiSelect={(e) => {
-                                    setIcon(e.native);
-                                    setShowPicker(false);
-                                }}
-                            />
-                            )}
+                            <>
+                                <div
+                                    style={{ position: "fixed", inset: 0, zIndex: 9998 }}
+                                    onClick={() => setShowPicker(false)}
+                                />
+                                <div style={{ position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)", zIndex: 9999 }}>
+                                    <Picker
+                                        data={data}
+                                        locale="ja"
+                                        onEmojiSelect={(e) => {
+                                            setIcon(e.native);
+                                            setShowPicker(false);
+                                        }}
+                                    />
+                                </div>
+                            </>
+                        )}
                     </div>
                     <div className="modal-field">
                         <label>カテゴリ名</label>


### PR DESCRIPTION
## 概要

- ダッシュボードのカードグリッド末尾に「＋ 追加」ボタンを追加
- クリックで `CategoryFormModal` を表示、追加後にactivity一覧を自動リロード
- 絵文字ピッカーを `position: fixed` で画面中央に表示（モーダル内でのはみ出しを解消）
- `CategoryFormModal` を `<form>` の外に配置しフォームネストによる追加失敗を修正

## 役割分担
- ダッシュボード：カテゴリ追加のみ
- 設定画面：削除・ON/OFFなどの管理

## 動作確認

- [ ] ダッシュボードの「＋ 追加」からカテゴリを追加できる
- [ ] 追加後にカードが即座に反映される
- [ ] 設定画面のカテゴリ追加も引き続き動作する