### PR TITLE
fix: ダッシュボードのカテゴリ追加モーダルの表示崩れを修正する

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -440,8 +440,10 @@ html, body {
   inset: 0;
   background: rgba(0, 0, 0, 0.4);
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
+  padding: 40px 16px;
+  overflow-y: auto;
   z-index: 1000;
 }
 
@@ -451,9 +453,15 @@ html, body {
   padding: 24px;
   width: 480px;
   max-width: 90vw;
+  max-height: 85vh;
+  overflow-y: auto;
   box-sizing: border-box;
   position: relative;
-  overflow: visible;
+
+  em-emoji-picker {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
 }
 
 .modal-title {
@@ -541,6 +549,7 @@ html, body {
   font-size: 1.25rem;
   cursor: pointer;
   color: #888;
+  z-index: 1200;
   &:hover { color: #333; }
 }
 

--- a/app/javascript/react/dashboard/DashboardApp.jsx
+++ b/app/javascript/react/dashboard/DashboardApp.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
 import LogForm from "./components/LogForm";
 import TodayHistory from "./components/TodayHistory";
-import CurrentStatus from "./components/CurrentStatus"; 
+import CurrentStatus from "./components/CurrentStatus";
 import SummaryStatus from "./components/SummaryStatus";
+import CategoryFormModal from "../settings/CategoryFormModal";
 import { fetchToday, fetchActivities, postLog, stopLog } from "./api";
 
 export default function DashboardApp() {
@@ -11,6 +12,7 @@ export default function DashboardApp() {
   const [error, setError] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [now, setNow] = useState(new Date());
+  const [showAddModal, setShowAddModal] = useState(false);
 
   async function loadAll() {
     setError(null);
@@ -105,7 +107,7 @@ export default function DashboardApp() {
             activities={activities}
             onSubmit={handleSubmit}
             isSubmitting={isSubmitting}
-            onActivityAdded={() => loadAll()}
+            onShowAddModal={() => setShowAddModal(true)}
           />
         </div>
         <div className="dashboard-right-col">
@@ -120,6 +122,13 @@ export default function DashboardApp() {
       </div>
 
       <TodayHistory logs={logs} activities={activities} now={now} dashboard={dashboard} />
+
+      {showAddModal && (
+        <CategoryFormModal
+          onClose={() => setShowAddModal(false)}
+          onAdd={() => { loadAll(); setShowAddModal(false); }}
+        />
+      )}
     </div>
   );
 }

--- a/app/javascript/react/dashboard/components/LogForm.jsx
+++ b/app/javascript/react/dashboard/components/LogForm.jsx
@@ -1,12 +1,10 @@
 import React, { useState } from "react";
-import CategoryFormModal from "../../settings/CategoryFormModal";
 
-export default function LogForm({ activities, onSubmit, isSubmitting, onActivityAdded }) {
+export default function LogForm({ activities, onSubmit, isSubmitting, onShowAddModal }) {
   const [selectedId, setSelectedId] = useState(null);
   const [memo, setMemo] = useState("");
   const [hoveredId, setHoveredId] = useState(null);
   const [btnHover, setBtnHover] = useState(false);
-  const [showAddModal, setShowAddModal] = useState(false);
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -94,7 +92,7 @@ export default function LogForm({ activities, onSubmit, isSubmitting, onActivity
           {/* カテゴリ追加ボタン */}
           <button
             type="button"
-            onClick={() => setShowAddModal(true)}
+            onClick={() => onShowAddModal?.()}
             onMouseEnter={() => setHoveredId("__add__")}
             onMouseLeave={() => setHoveredId(null)}
             style={{
@@ -171,15 +169,6 @@ export default function LogForm({ activities, onSubmit, isSubmitting, onActivity
         </button>
       </form>
 
-      {showAddModal && (
-        <CategoryFormModal
-          onClose={() => setShowAddModal(false)}
-          onAdd={(newActivity) => {
-            onActivityAdded?.(newActivity);
-            setShowAddModal(false);
-          }}
-        />
-      )}
     </div>
   );
 }

--- a/app/javascript/react/settings/CategoryFormModal.jsx
+++ b/app/javascript/react/settings/CategoryFormModal.jsx
@@ -53,22 +53,14 @@ export default function CategoryFormModal({ onClose, onAdd }) {
                             {icon || "＋ 選択"}
                         </button>
                         {showPicker && (
-                            <>
-                                <div
-                                    style={{ position: "fixed", inset: 0, zIndex: 9998 }}
-                                    onClick={() => setShowPicker(false)}
-                                />
-                                <div style={{ position: "fixed", top: "50%", left: "50%", transform: "translate(-50%, -50%)", zIndex: 9999 }}>
-                                    <Picker
-                                        data={data}
-                                        locale="ja"
-                                        onEmojiSelect={(e) => {
-                                            setIcon(e.native);
-                                            setShowPicker(false);
-                                        }}
-                                    />
-                                </div>
-                            </>
+                            <Picker
+                                data={data}
+                                locale="ja"
+                                onEmojiSelect={(e) => {
+                                    setIcon(e.native);
+                                    setShowPicker(false);
+                                }}
+                            />
                         )}
                     </div>
                     <div className="modal-field">


### PR DESCRIPTION
## 概要

- モーダルを `LogForm` から `DashboardApp` 直下に移動し、`backdropFilter` による `position: fixed` の封じ込めを解消
- 絵文字ピッカーをインライン表示に戻し、`modal-overlay` をスクロール対応に変更
- `modal-overlay` に `flex-start` + `padding` を設定し、モーダルが画面内に収まるよう改善

## 動作確認

- [ ] ダッシュボードで「＋ 追加」を押すと全画面オーバーレイでモーダルが表示される
- [ ] 絵文字を選択してカテゴリ名を入力し追加できる
- [ ] 設定画面のカテゴリ追加も引き続き正常に動作する