### PR TITLE
fix: 日付変更時にダッシュボードを自動リロードする

### DIFF
--- a/app/javascript/react/dashboard/DashboardApp.jsx
+++ b/app/javascript/react/dashboard/DashboardApp.jsx
@@ -28,6 +28,15 @@ export default function DashboardApp() {
 
   useEffect(() => { loadAll(); }, []);
 
+  // 日付が変わったらページをリロード
+  useEffect(() => {
+    const tomorrow = new Date();
+    tomorrow.setHours(24, 0, 0, 0);
+    const msUntilMidnight = tomorrow - Date.now();
+    const timer = setTimeout(() => { window.location.reload(); }, msUntilMidnight);
+    return () => clearTimeout(timer);
+  }, []);
+
   // 1秒ごとにnowを更新
   useEffect(() => {
     const currentLog = dashboard?.current_log;


### PR DESCRIPTION
## 概要

- 日付をまたいでダッシュボードを開いたままにしていると表示が古いままになる問題を修正
- マウント時に深夜0時までの時間を計算し、`setTimeout` で自動リロードをセット

## 背景

`loadAll()` はマウント時の1回のみ実行されるため、ページを開いたまま日付をまたぐとログ一覧・合計時間が前日のデータのまま表示されていた。

## 動作確認

- [ ] ダッシュボードを開いたまま深夜0時を過ぎると自動でリロードされることを確認