### PR TITLE
fix: ActivityをcurrentUser経由で取得するよう修正する

### DIFF
--- a/app/controllers/api/dashboard_logs_controller.rb
+++ b/app/controllers/api/dashboard_logs_controller.rb
@@ -2,7 +2,7 @@ class Api::DashboardLogsController < ApplicationController
   before_action :authenticate_user!
 
   def create
-    activity = Activity.find_by!(public_id: params[:activity_id])
+    activity = current_user.activities.find_by!(public_id: params[:activity_id])
     now = trusted_client_time(params[:logged_at])
 
     cutoff = [now.beginning_of_day, now - 6.hours].min

--- a/app/controllers/api/weekly_goals_controller.rb
+++ b/app/controllers/api/weekly_goals_controller.rb
@@ -3,7 +3,7 @@ class Api::WeeklyGoalsController < ApplicationController
 
   def upsert
     week_start = Date.parse(params[:week_start])
-    activity = Activity.find_by(public_id: params[:activity_id])
+    activity = current_user.activities.find_by(public_id: params[:activity_id])
     return render json: { errors: ["カテゴリが見つかりません"] }, status: :not_found unless activity
 
     goal = current_user.weekly_goals.find_or_initialize_by(week_start: week_start)


### PR DESCRIPTION
closes #357

## 概要

- `Activity.find_by` で他ユーザーのActivityにアクセスできてしまうセキュリティ上の問題を修正
- `dashboard_logs_controller.rb` と `weekly_goals_controller.rb` で `current_user.activities.find_by` に変更

## 動作確認

- [ ] `bundle exec rspec spec/` で 149 examples, 0 failures を確認
- [ ] 行動の記録・週次目標の設定が正常に動作することを確認